### PR TITLE
Sync erasers for Late Joiners

### DIFF
--- a/Assets/_WorldJam1/Drawing/LineMaterials/FountainPenLine.mat
+++ b/Assets/_WorldJam1/Drawing/LineMaterials/FountainPenLine.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: FountainPenLine
-  m_Shader: {fileID: 4800000, guid: 8b39b95ac85682040beff730e0cfc77a, type: 3}
+  m_Shader: {fileID: 4800000, guid: 2dcd9e0568e0a6f45b92c60ba2eb16a0, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Assets/_WorldJam1/Drawing/LineMaterials/PremiumBrushLine.mat
+++ b/Assets/_WorldJam1/Drawing/LineMaterials/PremiumBrushLine.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: PremiumBrushLine
-  m_Shader: {fileID: 4800000, guid: 8b39b95ac85682040beff730e0cfc77a, type: 3}
+  m_Shader: {fileID: 4800000, guid: 2dcd9e0568e0a6f45b92c60ba2eb16a0, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Assets/_WorldJam1/Drawing/LineMaterials/StylusLine.mat
+++ b/Assets/_WorldJam1/Drawing/LineMaterials/StylusLine.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: StylusLine
-  m_Shader: {fileID: 4800000, guid: 8b39b95ac85682040beff730e0cfc77a, type: 3}
+  m_Shader: {fileID: 4800000, guid: 2dcd9e0568e0a6f45b92c60ba2eb16a0, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Assets/_WorldJam1/Drawing/LineMaterials/WoodBrushLine.mat
+++ b/Assets/_WorldJam1/Drawing/LineMaterials/WoodBrushLine.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: WoodBrushLine
-  m_Shader: {fileID: 4800000, guid: 8b39b95ac85682040beff730e0cfc77a, type: 3}
+  m_Shader: {fileID: 4800000, guid: 2dcd9e0568e0a6f45b92c60ba2eb16a0, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Assets/_WorldJam1/Drawing/UdonPrograms/Eraser.asset
+++ b/Assets/_WorldJam1/Drawing/UdonPrograms/Eraser.asset
@@ -31,7 +31,9 @@ MonoBehaviour:
     %SystemBoolean, null\r\n    instance_4: %VRCUdonUdonBehaviour, this\r\n    target_0:
     %VRCUdonCommonInterfacesNetworkEventTarget, null\r\n    eventName_0: %SystemString,
     null\r\n    var_1: %SystemObject, null\r\n    object_6: %SystemObject, null\r\n
-    \   result_6: %SystemBoolean, null\r\n    instance_5: %UnityEngineLineRenderer,
+    \   result_6: %SystemBoolean, null\r\n    Boolean_2: %SystemBoolean, null\r\n
+    \   instance_5: %UnityEngineCollider, null\r\n    other_1: %SystemObject, null\r\n
+    \   onTriggerStayOther: %UnityEngineCollider, null\r\n    instance_6: %UnityEngineLineRenderer,
     null\r\n    value_1: %SystemBoolean, null\r\n    Single_0: %SystemSingle, null\r\n
     \   Single_1: %SystemSingle, null\r\n    f_0: %SystemSingle, null\r\n    Single_2:
     %SystemSingle, null\r\n    Single_3: %SystemSingle, null\r\n    target: %UnityEngineLineRenderer,
@@ -83,18 +85,23 @@ MonoBehaviour:
     target_0\r\n        PUSH, eventName_0\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomNetworkEvent__VRCUdonCommonInterfacesNetworkEventTarget_SystemString__SystemVoid\"\r\n
     \       PUSH, var_1\r\n        PUSH, target\r\n        COPY\r\n        PUSH, var_1\r\n
     \       PUSH, targetBehaviour\r\n        COPY\r\n        JUMP, 0x000003D4\r\n
-    \       JUMP, 0xFFFFFFFC\r\n    \r\n    .export _update\r\n    \r\n    _update:\r\n
+    \       JUMP, 0xFFFFFFFC\r\n    \r\n    .export _onTriggerStay\r\n    \r\n    _onTriggerStay:\r\n
     \   \r\n        PUSH, target\r\n        PUSH, object_6\r\n        COPY\r\n        PUSH,
     object_6\r\n        PUSH, result_6\r\n        EXTERN, \"VRCSDKBaseUtilities.__IsValid__SystemObject__SystemBoolean\"\r\n
-    \       PUSH, result_6\r\n        JUMP_IF_FALSE, 0x000004B4\r\n        PUSH, target\r\n
-    \       PUSH, instance_5\r\n        COPY\r\n        PUSH, Single_2\r\n        EXTERN,
-    \"UnityEngineTime.__get_time__SystemSingle\"\r\n        PUSH, Single_2\r\n        PUSH,
-    blinkSpeed\r\n        PUSH, f_0\r\n        EXTERN, \"SystemSingle.__op_Multiplication__SystemSingle_SystemSingle__SystemSingle\"\r\n
+    \       PUSH, result_6\r\n        JUMP_IF_FALSE, 0x00000514\r\n        PUSH, onTriggerStayOther\r\n
+    \       PUSH, instance_5\r\n        COPY\r\n        PUSH, targetCollider\r\n        PUSH,
+    other_1\r\n        COPY\r\n        PUSH, instance_5\r\n        PUSH, other_1\r\n
+    \       PUSH, Boolean_2\r\n        EXTERN, \"UnityEngineCollider.__Equals__SystemObject__SystemBoolean\"\r\n
+    \       PUSH, Boolean_2\r\n        JUMP_IF_FALSE, 0x0000050C\r\n        PUSH,
+    target\r\n        PUSH, instance_6\r\n        COPY\r\n        PUSH, Single_2\r\n
+    \       EXTERN, \"UnityEngineTime.__get_time__SystemSingle\"\r\n        PUSH,
+    Single_2\r\n        PUSH, blinkSpeed\r\n        PUSH, f_0\r\n        EXTERN, \"SystemSingle.__op_Multiplication__SystemSingle_SystemSingle__SystemSingle\"\r\n
     \       PUSH, f_0\r\n        PUSH, Single_0\r\n        EXTERN, \"UnityEngineMathf.__Sin__SystemSingle__SystemSingle\"\r\n
     \       PUSH, Single_0\r\n        PUSH, Single_1\r\n        PUSH, value_1\r\n
     \       EXTERN, \"SystemSingle.__op_GreaterThan__SystemSingle_SystemSingle__SystemBoolean\"\r\n
-    \       PUSH, instance_5\r\n        PUSH, value_1\r\n        EXTERN, \"UnityEngineLineRenderer.__set_enabled__SystemBoolean__SystemVoid\"\r\n
-    \       JUMP, 0x000004B4\r\n        JUMP, 0xFFFFFFFC\r\n    \r\n\r\n.code_end\r\n"
+    \       PUSH, instance_6\r\n        PUSH, value_1\r\n        EXTERN, \"UnityEngineLineRenderer.__set_enabled__SystemBoolean__SystemVoid\"\r\n
+    \       JUMP, 0x0000050C\r\n        JUMP, 0x00000514\r\n        JUMP, 0xFFFFFFFC\r\n
+    \   \r\n\r\n.code_end\r\n"
   assemblyError: 
   graphData:
     name: 
@@ -204,7 +211,8 @@ MonoBehaviour:
       nodeUIDs:
       - 
       - 02e8d602-2950-46c8-8822-a13470f8b67b|0
-      flowUIDs: []
+      flowUIDs:
+      - 
       nodeValues:
       - unityObjectValue: {fileID: 0}
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|9b3209fa-3a57-4bb3-b6f4-e74b245276b9
@@ -302,16 +310,9 @@ MonoBehaviour:
       nodeValues:
       - unityObjectValue: {fileID: 0}
         stringValue: 
-    - fullName: Event_Update
-      uid: 245e28a0-6434-4a6f-b338-c3e67c4ad189
-      position: {x: 280, y: 1730}
-      nodeUIDs: []
-      flowUIDs:
-      - 83606da2-5116-4377-a464-fc5896cd98a8
-      nodeValues: []
     - fullName: Get_Variable
       uid: ecd01fd5-ca02-4598-aef5-2ff06b76ce51
-      position: {x: 200, y: 1840}
+      position: {x: 780, y: 1780}
       nodeUIDs:
       - ecd01fd5-ca02-4598-aef5-2ff06b76ce51|0
       flowUIDs: []
@@ -322,17 +323,17 @@ MonoBehaviour:
         stringValue: 
     - fullName: Is_Valid
       uid: 83606da2-5116-4377-a464-fc5896cd98a8
-      position: {x: 420, y: 1750}
+      position: {x: 540, y: 1650}
       nodeUIDs:
-      - ecd01fd5-ca02-4598-aef5-2ff06b76ce51|0
+      - 6732d43d-9858-42f3-a62b-e68b29a8e1bf|0
       flowUIDs:
-      - f58028b3-ad52-4e6a-94e0-8c5390ad94bf
+      - 8925bec2-996a-4afe-9dcc-5d5522ffbf2e
       nodeValues:
       - unityObjectValue: {fileID: 0}
         stringValue: 
     - fullName: UnityEngineLineRenderer.__set_enabled__SystemBoolean__SystemVoid
       uid: f58028b3-ad52-4e6a-94e0-8c5390ad94bf
-      position: {x: 1080, y: 1780}
+      position: {x: 980, y: 1650}
       nodeUIDs:
       - ecd01fd5-ca02-4598-aef5-2ff06b76ce51|0
       - d6e9248c-3076-4b11-9871-63f30312d6cb|0
@@ -344,13 +345,13 @@ MonoBehaviour:
         stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|False
     - fullName: UnityEngineTime.__get_time__SystemSingle
       uid: e1632a15-b2cc-4587-b662-a9621d3badce
-      position: {x: 380, y: 1950}
+      position: {x: 320, y: 1980}
       nodeUIDs: []
       flowUIDs: []
       nodeValues: []
     - fullName: UnityEngineMathf.__Sin__SystemSingle__SystemSingle
       uid: 6df5e8d4-5f67-4f95-94f1-6ef8c0cf111c
-      position: {x: 700, y: 1940}
+      position: {x: 640, y: 1970}
       nodeUIDs:
       - 1a861f61-2dc1-4d36-95cb-2e52bee2bf6a|0
       flowUIDs: []
@@ -359,7 +360,7 @@ MonoBehaviour:
         stringValue: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0
     - fullName: SystemSingle.__op_GreaterThan__SystemSingle_SystemSingle__SystemBoolean
       uid: d6e9248c-3076-4b11-9871-63f30312d6cb
-      position: {x: 860, y: 1920}
+      position: {x: 800, y: 1950}
       nodeUIDs:
       - 6df5e8d4-5f67-4f95-94f1-6ef8c0cf111c|0
       - 
@@ -371,7 +372,7 @@ MonoBehaviour:
         stringValue: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0
     - fullName: SystemSingle.__op_Multiplication__SystemSingle_SystemSingle__SystemSingle
       uid: 1a861f61-2dc1-4d36-95cb-2e52bee2bf6a
-      position: {x: 540, y: 1950}
+      position: {x: 480, y: 1980}
       nodeUIDs:
       - e1632a15-b2cc-4587-b662-a9621d3badce|0
       - b343c982-3a97-4154-93c9-d7bd90547adc|0
@@ -404,7 +405,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|none
     - fullName: Get_Variable
       uid: b343c982-3a97-4154-93c9-d7bd90547adc
-      position: {x: 340, y: 2050}
+      position: {x: 280, y: 2080}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -586,6 +587,57 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|00e43a32-0d86-44af-88ee-aae47b18087b
       - unityObjectValue: {fileID: 0}
         stringValue: 
+    - fullName: Event_OnTriggerStay
+      uid: 4eeed13c-0bb0-482a-8d55-9f17eb27dba8
+      position: {x: 100, y: 1650}
+      nodeUIDs: []
+      flowUIDs:
+      - 83606da2-5116-4377-a464-fc5896cd98a8
+      nodeValues: []
+    - fullName: UnityEngineCollider.__Equals__SystemObject__SystemBoolean
+      uid: 795a7b68-d632-444a-87a2-8da5332af2c6
+      position: {x: 380, y: 1820}
+      nodeUIDs:
+      - 4eeed13c-0bb0-482a-8d55-9f17eb27dba8|0
+      - 13142046-2ee6-4f88-bee0-d52b6c713284|0
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+    - fullName: Get_Variable
+      uid: 13142046-2ee6-4f88-bee0-d52b6c713284
+      position: {x: 160, y: 1840}
+      nodeUIDs:
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|d988a67c-3ea4-4916-b7ee-8c4ed2558451
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+    - fullName: Get_Variable
+      uid: 6732d43d-9858-42f3-a62b-e68b29a8e1bf
+      position: {x: 340, y: 1730}
+      nodeUIDs:
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|9b3209fa-3a57-4bb3-b6f4-e74b245276b9
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+    - fullName: Branch
+      uid: 8925bec2-996a-4afe-9dcc-5d5522ffbf2e
+      position: {x: 720, y: 1650}
+      nodeUIDs:
+      - 795a7b68-d632-444a-87a2-8da5332af2c6|0
+      flowUIDs:
+      - f58028b3-ad52-4e6a-94e0-8c5390ad94bf
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|False
     updateOrder: 0
   graphElementData:
   - type: 2
@@ -602,7 +654,7 @@ MonoBehaviour:
       LineRenderer and clear Target","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: de8e2439-785e-4270-b20f-56d7f20f7ec4
-    jsonData: '{"uid":"de8e2439-785e-4270-b20f-56d7f20f7ec4","layout":{"serializedVersion":"2","x":180.0,"y":1670.0,"width":1077.0,"height":492.0},"containedElements":["1a861f61-2dc1-4d36-95cb-2e52bee2bf6a","d6e9248c-3076-4b11-9871-63f30312d6cb","6df5e8d4-5f67-4f95-94f1-6ef8c0cf111c","e1632a15-b2cc-4587-b662-a9621d3badce","f58028b3-ad52-4e6a-94e0-8c5390ad94bf","83606da2-5116-4377-a464-fc5896cd98a8","ecd01fd5-ca02-4598-aef5-2ff06b76ce51","245e28a0-6434-4a6f-b338-c3e67c4ad189","b343c982-3a97-4154-93c9-d7bd90547adc"],"title":"Make
+    jsonData: '{"uid":"de8e2439-785e-4270-b20f-56d7f20f7ec4","layout":{"serializedVersion":"2","x":80.0,"y":1580.0,"width":1074.0,"height":604.0},"containedElements":["1a861f61-2dc1-4d36-95cb-2e52bee2bf6a","d6e9248c-3076-4b11-9871-63f30312d6cb","6df5e8d4-5f67-4f95-94f1-6ef8c0cf111c","e1632a15-b2cc-4587-b662-a9621d3badce","f58028b3-ad52-4e6a-94e0-8c5390ad94bf","83606da2-5116-4377-a464-fc5896cd98a8","ecd01fd5-ca02-4598-aef5-2ff06b76ce51","245e28a0-6434-4a6f-b338-c3e67c4ad189","b343c982-3a97-4154-93c9-d7bd90547adc","4eeed13c-0bb0-482a-8d55-9f17eb27dba8","795a7b68-d632-444a-87a2-8da5332af2c6","13142046-2ee6-4f88-bee0-d52b6c713284","d5f3c53e-48ce-47ff-b900-69685018ed77","4f5ff33f-21f6-40e1-b46d-78c067e1dcd0","da5b3e6a-4898-4e26-919f-bbbfdd7a7882","814c99fe-9ce8-4b3a-a080-7bdd83868c07","6732d43d-9858-42f3-a62b-e68b29a8e1bf","c36dfec3-2266-4076-add9-86408772b9f7","3817cfa5-6feb-4b36-8df2-1caf0ff8ad78","9a1826c3-984d-41b3-8997-f9b204a38bd5","0a527ed9-ebb2-4712-b3f2-5cc96075d3b2","8925bec2-996a-4afe-9dcc-5d5522ffbf2e"],"title":"Make
       Target Line Blink","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 5
     uid: b599b382-55b3-49c3-a824-9924bf756def
@@ -611,7 +663,7 @@ MonoBehaviour:
     uid: 44ecb895-be4c-4688-ad0a-172eca4195a2
     jsonData: '{"visible":true,"layout":{"serializedVersion":"2","x":10.0,"y":20.0,"width":0.0,"height":0.0}}'
   viewTransform:
-    position: {x: 77.918434, y: 125.43764}
-    scale: 0.65751624
+    position: {x: 31.428978, y: -512.7648}
+    scale: 0.7561437
   version: 1.0.0
   showAssembly: 0

--- a/Assets/_WorldJam1/Drawing/UdonPrograms/PenBase.asset
+++ b/Assets/_WorldJam1/Drawing/UdonPrograms/PenBase.asset
@@ -1336,7 +1336,7 @@ MonoBehaviour:
     uid: 2c6f8b54-7ea8-492c-abb7-97607b64793d
     jsonData: '{"visible":true,"layout":{"serializedVersion":"2","x":10.0,"y":20.0,"width":0.0,"height":0.0}}'
   viewTransform:
-    position: {x: -2533.0537, y: 303.83862}
+    position: {x: 557.4447, y: 391.7594}
     scale: 0.8695652
   version: 1.0.0
   showAssembly: 0

--- a/Assets/_WorldJam1/Drawing/UdonPrograms/PenLineBasic.asset
+++ b/Assets/_WorldJam1/Drawing/UdonPrograms/PenLineBasic.asset
@@ -21,31 +21,34 @@ MonoBehaviour:
     null\r\n    eventName_1: %SystemString, null\r\n    instance_3: %UnityEngineLineRenderer,
     null\r\n    value_0: %SystemInt32, null\r\n    instance_4: %UnityEngineVector3Array,
     null\r\n    instance_5: %UnityEngineLineRenderer, null\r\n    positions_0: %UnityEngineVector3Array,
-    null\r\n    Boolean_0: %SystemBoolean, null\r\n    Int32_3: %SystemInt32, null\r\n
-    \   instance_6: %UnityEngineLineRenderer, null\r\n    positions_1: %UnityEngineVector3Array,
-    null\r\n    Int32_0: %SystemInt32, null\r\n    Int32_1: %SystemInt32, null\r\n
-    \   Int32_2: %SystemInt32, null\r\n    instance_7: %UnityEngineLineRenderer, null\r\n
-    \   instance_8: %VRCUdonUdonBehaviour, this\r\n    object_0: %SystemObject, null\r\n
-    \   Type_0: %SystemType, null\r\n    result_0: %SystemBoolean, null\r\n    instance_9:
+    null\r\n    instance_6: %UnityEngineLineRenderer, null\r\n    value_1: %SystemBoolean,
+    null\r\n    Boolean_0: %SystemBoolean, null\r\n    Int32_1: %SystemInt32, null\r\n
+    \   instance_7: %UnityEngineLineRenderer, null\r\n    positions_1: %UnityEngineVector3Array,
+    null\r\n    Int32_0: %SystemInt32, null\r\n    instance_8: %UnityEngineLineRenderer,
+    null\r\n    instance_9: %VRCUdonUdonBehaviour, this\r\n    instance_A: %UnityEngineLineRenderer,
+    null\r\n    value_2: %SystemBoolean, null\r\n    object_0: %SystemObject, null\r\n
+    \   Type_0: %SystemType, null\r\n    result_0: %SystemBoolean, null\r\n    instance_B:
     %UnityEngineGameObject, this\r\n    type_0: %SystemType, null\r\n    Type_1: %SystemType,
     null\r\n    message_0: %SystemObject, null\r\n    format_0: %SystemString, null\r\n
     \   arg0_0: %SystemObject, null\r\n    arg1_0: %SystemObject, null\r\n    Type_2:
     %SystemType, null\r\n    object_1: %SystemObject, null\r\n    Type_3: %SystemType,
-    null\r\n    result_1: %SystemBoolean, null\r\n    instance_B: %UnityEngineGameObject,
+    null\r\n    result_1: %SystemBoolean, null\r\n    instance_D: %UnityEngineGameObject,
     this\r\n    type_1: %SystemType, null\r\n    Type_4: %SystemType, null\r\n    message_1:
     %SystemObject, null\r\n    format_1: %SystemString, null\r\n    arg0_1: %SystemObject,
-    null\r\n    arg1_1: %SystemObject, null\r\n    Type_5: %SystemType, null\r\n    instance_A:
+    null\r\n    arg1_1: %SystemObject, null\r\n    Type_5: %SystemType, null\r\n    instance_C:
     %UnityEngineGameObject, this\r\n    GameObject_0: %UnityEngineGameObject, this\r\n
-    \   instance_C: %UnityEngineGameObject, this\r\n    value_1: %SystemBoolean, null\r\n
-    \   instance_D: %UnityEngineLineRenderer, null\r\n    mesh_0: %UnityEngineMesh,
-    null\r\n    useTransform_0: %SystemBoolean, null\r\n    instance_E: %UnityEngineMeshCollider,
-    null\r\n    value_2: %UnityEngineMesh, null\r\n    isDown: %SystemBoolean, null\r\n
-    \   points: %UnityEngineVector3Array, null\r\n    lineRenderer: %UnityEngineLineRenderer,
-    null\r\n    __returnValue: %SystemObject, null\r\n    lineMesh: %UnityEngineMesh,
-    null\r\n    lineCollider: %UnityEngineMeshCollider, null\r\n\r\n.data_end\r\n\r\n.code_start\r\n\r\n
-    \   .export OnFinish\r\n    \r\n    OnFinish:\r\n    \r\n        PUSH, lineRenderer\r\n
-    \       PUSH, instance_0\r\n        COPY\r\n        PUSH, instance_0\r\n        PUSH,
-    tolerance_0\r\n        EXTERN, \"UnityEngineLineRenderer.__Simplify__SystemSingle__SystemVoid\"\r\n
+    \   Boolean_1: %SystemBoolean, null\r\n    obj_0: %UnityEngineGameObject, this\r\n
+    \   instance_E: %UnityEngineLineRenderer, null\r\n    value_3: %SystemInt32, null\r\n
+    \   instance_F: %VRCUdonUdonBehaviour, this\r\n    eventName_2: %SystemString,
+    null\r\n    instance_10: %UnityEngineLineRenderer, null\r\n    mesh_0: %UnityEngineMesh,
+    null\r\n    useTransform_0: %SystemBoolean, null\r\n    instance_11: %UnityEngineMeshCollider,
+    null\r\n    value_4: %UnityEngineMesh, null\r\n    points: %UnityEngineVector3Array,
+    null\r\n    lineRenderer: %UnityEngineLineRenderer, null\r\n    __returnValue:
+    %SystemObject, null\r\n    lineMesh: %UnityEngineMesh, null\r\n    lineCollider:
+    %UnityEngineMeshCollider, null\r\n\r\n.data_end\r\n\r\n.code_start\r\n\r\n    .export
+    OnFinish\r\n    \r\n    OnFinish:\r\n    \r\n        PUSH, lineRenderer\r\n        PUSH,
+    instance_0\r\n        COPY\r\n        PUSH, instance_0\r\n        PUSH, tolerance_0\r\n
+    \       EXTERN, \"UnityEngineLineRenderer.__Simplify__SystemSingle__SystemVoid\"\r\n
     \       PUSH, instance_1\r\n        PUSH, eventName_0\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid\"\r\n
     \       PUSH, instance_2\r\n        PUSH, target_0\r\n        PUSH, eventName_1\r\n
     \       EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomNetworkEvent__VRCUdonCommonInterfacesNetworkEventTarget_SystemString__SystemVoid\"\r\n
@@ -58,88 +61,73 @@ MonoBehaviour:
     \       PUSH, lineRenderer\r\n        PUSH, instance_5\r\n        COPY\r\n        PUSH,
     points\r\n        PUSH, positions_0\r\n        COPY\r\n        PUSH, instance_5\r\n
     \       PUSH, positions_0\r\n        EXTERN, \"UnityEngineLineRenderer.__SetPositions__UnityEngineVector3Array__SystemVoid\"\r\n
+    \       PUSH, lineRenderer\r\n        PUSH, instance_6\r\n        COPY\r\n        PUSH,
+    instance_6\r\n        PUSH, value_1\r\n        EXTERN, \"UnityEngineLineRenderer.__set_enabled__SystemBoolean__SystemVoid\"\r\n
     \       JUMP, 0xFFFFFFFC\r\n    \r\n    .export _onOwnershipRequest\r\n    \r\n
     \   _onOwnershipRequest:\r\n    \r\n        PUSH, Boolean_0\r\n        PUSH, __returnValue\r\n
     \       COPY\r\n        JUMP, 0xFFFFFFFC\r\n    \r\n    .export OnUpdate\r\n    \r\n
-    \   OnUpdate:\r\n    \r\n        PUSH, lineRenderer\r\n        PUSH, instance_6\r\n
-    \       COPY\r\n        PUSH, lineRenderer\r\n        PUSH, instance_7\r\n        COPY\r\n
-    \       PUSH, instance_7\r\n        PUSH, Int32_1\r\n        EXTERN, \"UnityEngineLineRenderer.__get_positionCount__SystemInt32\"\r\n
-    \       PUSH, Int32_1\r\n        PUSH, Int32_2\r\n        PUSH, Int32_0\r\n        EXTERN,
-    \"SystemInt32.__op_Subtraction__SystemInt32_SystemInt32__SystemInt32\"\r\n        PUSH,
-    Int32_0\r\n        PUSH, positions_1\r\n        EXTERN, \"UnityEngineVector3Array.__ctor__SystemInt32__UnityEngineVector3Array\"\r\n
-    \       PUSH, instance_6\r\n        PUSH, positions_1\r\n        PUSH, Int32_3\r\n
+    \   OnUpdate:\r\n    \r\n        PUSH, lineRenderer\r\n        PUSH, instance_7\r\n
+    \       COPY\r\n        PUSH, lineRenderer\r\n        PUSH, instance_8\r\n        COPY\r\n
+    \       PUSH, instance_8\r\n        PUSH, Int32_0\r\n        EXTERN, \"UnityEngineLineRenderer.__get_positionCount__SystemInt32\"\r\n
+    \       PUSH, Int32_0\r\n        PUSH, positions_1\r\n        EXTERN, \"UnityEngineVector3Array.__ctor__SystemInt32__UnityEngineVector3Array\"\r\n
+    \       PUSH, instance_7\r\n        PUSH, positions_1\r\n        PUSH, Int32_1\r\n
     \       EXTERN, \"UnityEngineLineRenderer.__GetPositions__UnityEngineVector3Array__SystemInt32\"\r\n
-    \       PUSH, lineRenderer\r\n        PUSH, instance_6\r\n        COPY\r\n        PUSH,
-    lineRenderer\r\n        PUSH, instance_7\r\n        COPY\r\n        PUSH, positions_1\r\n
+    \       PUSH, lineRenderer\r\n        PUSH, instance_7\r\n        COPY\r\n        PUSH,
+    lineRenderer\r\n        PUSH, instance_8\r\n        COPY\r\n        PUSH, positions_1\r\n
     \       PUSH, points\r\n        COPY\r\n        PUSH, positions_1\r\n        PUSH,
-    points\r\n        COPY\r\n        PUSH, instance_8\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__RequestSerialization__SystemVoid\"\r\n
+    points\r\n        COPY\r\n        PUSH, instance_9\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__RequestSerialization__SystemVoid\"\r\n
+    \       PUSH, lineRenderer\r\n        PUSH, instance_A\r\n        COPY\r\n        PUSH,
+    instance_A\r\n        PUSH, value_2\r\n        EXTERN, \"UnityEngineLineRenderer.__set_enabled__SystemBoolean__SystemVoid\"\r\n
     \       JUMP, 0xFFFFFFFC\r\n    \r\n    .export _start\r\n    \r\n    _start:\r\n
-    \   \r\n        PUSH, GameObject_0\r\n        PUSH, instance_9\r\n        COPY\r\n
+    \   \r\n        PUSH, GameObject_0\r\n        PUSH, instance_B\r\n        COPY\r\n
     \       PUSH, Type_0\r\n        PUSH, type_0\r\n        COPY\r\n        PUSH,
-    instance_9\r\n        PUSH, type_0\r\n        PUSH, object_0\r\n        EXTERN,
+    instance_B\r\n        PUSH, type_0\r\n        PUSH, object_0\r\n        EXTERN,
     \"UnityEngineGameObject.__GetComponent__SystemType__UnityEngineComponent\"\r\n
     \       PUSH, object_0\r\n        PUSH, result_0\r\n        EXTERN, \"VRCSDKBaseUtilities.__IsValid__SystemObject__SystemBoolean\"\r\n
-    \       PUSH, result_0\r\n        JUMP_IF_FALSE, 0x000002F0\r\n        PUSH, GameObject_0\r\n
-    \       PUSH, instance_9\r\n        COPY\r\n        PUSH, Type_1\r\n        PUSH,
+    \       PUSH, result_0\r\n        JUMP_IF_FALSE, 0x00000328\r\n        PUSH, GameObject_0\r\n
+    \       PUSH, instance_B\r\n        COPY\r\n        PUSH, Type_1\r\n        PUSH,
     type_0\r\n        COPY\r\n        PUSH, object_0\r\n        PUSH, lineRenderer\r\n
     \       COPY\r\n        PUSH, object_0\r\n        PUSH, lineRenderer\r\n        COPY\r\n
-    \       JUMP, 0x00000368\r\n        PUSH, Type_2\r\n        PUSH, arg0_0\r\n        COPY\r\n
-    \       PUSH, GameObject_0\r\n        PUSH, instance_A\r\n        COPY\r\n        PUSH,
-    instance_A\r\n        PUSH, arg1_0\r\n        EXTERN, \"UnityEngineGameObject.__get_name__SystemString\"\r\n
+    \       JUMP, 0x000003A0\r\n        PUSH, Type_2\r\n        PUSH, arg0_0\r\n        COPY\r\n
+    \       PUSH, GameObject_0\r\n        PUSH, instance_C\r\n        COPY\r\n        PUSH,
+    instance_C\r\n        PUSH, arg1_0\r\n        EXTERN, \"UnityEngineGameObject.__get_name__SystemString\"\r\n
     \       PUSH, format_0\r\n        PUSH, arg0_0\r\n        PUSH, arg1_0\r\n        PUSH,
     message_0\r\n        EXTERN, \"SystemString.__Format__SystemString_SystemObject_SystemObject__SystemString\"\r\n
     \       PUSH, message_0\r\n        EXTERN, \"UnityEngineDebug.__Log__SystemObject__SystemVoid\"\r\n
-    \       PUSH, GameObject_0\r\n        PUSH, instance_B\r\n        COPY\r\n        PUSH,
-    Type_3\r\n        PUSH, type_1\r\n        COPY\r\n        PUSH, instance_B\r\n
+    \       PUSH, GameObject_0\r\n        PUSH, instance_D\r\n        COPY\r\n        PUSH,
+    Type_3\r\n        PUSH, type_1\r\n        COPY\r\n        PUSH, instance_D\r\n
     \       PUSH, type_1\r\n        PUSH, object_1\r\n        EXTERN, \"UnityEngineGameObject.__GetComponent__SystemType__UnityEngineComponent\"\r\n
     \       PUSH, object_1\r\n        PUSH, result_1\r\n        EXTERN, \"VRCSDKBaseUtilities.__IsValid__SystemObject__SystemBoolean\"\r\n
-    \       PUSH, result_1\r\n        JUMP_IF_FALSE, 0x00000430\r\n        PUSH, GameObject_0\r\n
-    \       PUSH, instance_B\r\n        COPY\r\n        PUSH, Type_4\r\n        PUSH,
+    \       PUSH, result_1\r\n        JUMP_IF_FALSE, 0x00000468\r\n        PUSH, GameObject_0\r\n
+    \       PUSH, instance_D\r\n        COPY\r\n        PUSH, Type_4\r\n        PUSH,
     type_1\r\n        COPY\r\n        PUSH, object_1\r\n        PUSH, lineCollider\r\n
     \       COPY\r\n        PUSH, object_1\r\n        PUSH, lineCollider\r\n        COPY\r\n
-    \       JUMP, 0x000004A4\r\n        PUSH, Type_5\r\n        PUSH, arg0_1\r\n        COPY\r\n
-    \       PUSH, GameObject_0\r\n        PUSH, instance_A\r\n        COPY\r\n        PUSH,
+    \       JUMP, 0x000004DC\r\n        PUSH, Type_5\r\n        PUSH, arg0_1\r\n        COPY\r\n
+    \       PUSH, GameObject_0\r\n        PUSH, instance_C\r\n        COPY\r\n        PUSH,
     arg1_0\r\n        PUSH, arg1_1\r\n        COPY\r\n        PUSH, format_1\r\n        PUSH,
     arg0_1\r\n        PUSH, arg1_0\r\n        PUSH, message_1\r\n        EXTERN, \"SystemString.__Format__SystemString_SystemObject_SystemObject__SystemString\"\r\n
     \       PUSH, message_1\r\n        EXTERN, \"UnityEngineDebug.__Log__SystemObject__SystemVoid\"\r\n
     \       PUSH, lineMesh\r\n        EXTERN, \"UnityEngineMesh.__ctor____UnityEngineMesh\"\r\n
     \       JUMP, 0xFFFFFFFC\r\n    \r\n    .export Erase\r\n    \r\n    Erase:\r\n
-    \   \r\n        PUSH, instance_C\r\n        PUSH, value_1\r\n        EXTERN, \"UnityEngineGameObject.__SetActive__SystemBoolean__SystemVoid\"\r\n
-    \       JUMP, 0xFFFFFFFC\r\n    \r\n    .export BakeMesh\r\n    \r\n    BakeMesh:\r\n
-    \   \r\n        PUSH, lineRenderer\r\n        PUSH, instance_D\r\n        COPY\r\n
-    \       PUSH, lineMesh\r\n        PUSH, mesh_0\r\n        COPY\r\n        PUSH,
-    instance_D\r\n        PUSH, mesh_0\r\n        PUSH, useTransform_0\r\n        EXTERN,
-    \"UnityEngineLineRenderer.__BakeMesh__UnityEngineMesh_SystemBoolean__SystemVoid\"\r\n
-    \       PUSH, lineCollider\r\n        PUSH, instance_E\r\n        COPY\r\n        PUSH,
-    lineMesh\r\n        PUSH, value_2\r\n        COPY\r\n        PUSH, instance_E\r\n
-    \       PUSH, value_2\r\n        EXTERN, \"UnityEngineMeshCollider.__set_sharedMesh__UnityEngineMesh__SystemVoid\"\r\n
+    \   \r\n        PUSH, obj_0\r\n        PUSH, Boolean_1\r\n        EXTERN, \"VRCSDKBaseNetworking.__IsOwner__UnityEngineGameObject__SystemBoolean\"\r\n
+    \       PUSH, Boolean_1\r\n        JUMP_IF_FALSE, 0x00000568\r\n        PUSH,
+    lineRenderer\r\n        PUSH, instance_E\r\n        COPY\r\n        PUSH, instance_E\r\n
+    \       PUSH, value_3\r\n        EXTERN, \"UnityEngineLineRenderer.__set_positionCount__SystemInt32__SystemVoid\"\r\n
+    \       PUSH, instance_F\r\n        PUSH, eventName_2\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid\"\r\n
+    \       JUMP, 0x00000568\r\n        JUMP, 0xFFFFFFFC\r\n    \r\n    .export BakeMesh\r\n
+    \   \r\n    BakeMesh:\r\n    \r\n        PUSH, lineRenderer\r\n        PUSH, instance_10\r\n
+    \       COPY\r\n        PUSH, lineMesh\r\n        PUSH, mesh_0\r\n        COPY\r\n
+    \       PUSH, instance_10\r\n        PUSH, mesh_0\r\n        PUSH, useTransform_0\r\n
+    \       EXTERN, \"UnityEngineLineRenderer.__BakeMesh__UnityEngineMesh_SystemBoolean__SystemVoid\"\r\n
+    \       PUSH, lineCollider\r\n        PUSH, instance_11\r\n        COPY\r\n        PUSH,
+    lineMesh\r\n        PUSH, value_4\r\n        COPY\r\n        PUSH, instance_11\r\n
+    \       PUSH, value_4\r\n        EXTERN, \"UnityEngineMeshCollider.__set_sharedMesh__UnityEngineMesh__SystemVoid\"\r\n
     \       JUMP, 0xFFFFFFFC\r\n    \r\n\r\n.code_end\r\n"
   assemblyError: 
   graphData:
     name: 
     description: 
     nodes:
-    - fullName: Variable_SystemBoolean
-      uid: 6e9852e8-4f32-4aae-b5d7-3c56b4e80462
-      position: {x: 0, y: 0}
-      nodeUIDs:
-      - 
-      - 
-      - 
-      - 
-      - 
-      flowUIDs: []
-      nodeValues:
-      - unityObjectValue: {fileID: 0}
-        stringValue: 
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|isDown
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|False
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|False
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|none
     - fullName: Event_Custom
       uid: dde4f88a-7917-4bae-b604-e70188cb63da
       position: {x: 110, y: -0}
@@ -195,7 +183,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|none
     - fullName: Get_Variable
       uid: aaf3e75f-5574-4790-8b3b-272131e9336e
-      position: {x: -1290, y: 50}
+      position: {x: -1420, y: 40}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -204,24 +192,24 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|d4139c3b-f0b7-4103-b844-bc897daa6ec5
     - fullName: VRCUdonCommonInterfacesIUdonEventReceiver.__RequestSerialization__SystemVoid
       uid: c6cd907a-9fa4-483b-8d26-a12cc00369d1
-      position: {x: -150, y: 10}
+      position: {x: -300, y: -0}
       nodeUIDs:
       - 
       flowUIDs:
-      - 
+      - 0231cabc-9956-4cfb-920f-08e39ec5eda3
       nodeValues:
       - unityObjectValue: {fileID: 0}
         stringValue: 
     - fullName: Event_OnDeserialization
       uid: 927d1cb8-d331-49d9-9531-c7bfe4b9c796
-      position: {x: -500, y: 710}
+      position: {x: -540, y: 690}
       nodeUIDs: []
       flowUIDs:
-      - cd88b179-20e7-4d23-842d-76f09578142d
+      - 1e9abd17-3958-473c-9584-5aa530207f4d
       nodeValues: []
     - fullName: Get_Variable
       uid: e11f63e2-0222-48dc-b22c-d1b58d2ddba0
-      position: {x: -280, y: 850}
+      position: {x: -300, y: 590}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -230,7 +218,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|4aaf2a0a-6354-4bce-b842-c305193d30b2
     - fullName: Get_Variable
       uid: 26b001e6-406f-4d3e-bd2c-0a5bb2e511d6
-      position: {x: -80, y: 830}
+      position: {x: -120, y: 550}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -239,7 +227,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|d4139c3b-f0b7-4103-b844-bc897daa6ec5
     - fullName: UnityEngineLineRenderer.__SetPositions__UnityEngineVector3Array__SystemVoid
       uid: f61dd935-f54c-41bf-b4c1-7f819e8ede51
-      position: {x: 360, y: 770}
+      position: {x: 320, y: 530}
       nodeUIDs:
       - 26b001e6-406f-4d3e-bd2c-0a5bb2e511d6|0
       - e11f63e2-0222-48dc-b22c-d1b58d2ddba0|0
@@ -252,7 +240,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: UnityEngineLineRenderer.__set_positionCount__SystemInt32__SystemVoid
       uid: cd88b179-20e7-4d23-842d-76f09578142d
-      position: {x: 160, y: 730}
+      position: {x: 120, y: 690}
       nodeUIDs:
       - 26b001e6-406f-4d3e-bd2c-0a5bb2e511d6|0
       - b08ad0aa-7980-402b-b9c3-9b9ab385febc|0
@@ -265,7 +253,7 @@ MonoBehaviour:
         stringValue: System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0
     - fullName: UnityEngineVector3Array.__get_Length__SystemInt32
       uid: b08ad0aa-7980-402b-b9c3-9b9ab385febc
-      position: {x: -80, y: 690}
+      position: {x: -60, y: 730}
       nodeUIDs:
       - e11f63e2-0222-48dc-b22c-d1b58d2ddba0|0
       flowUIDs: []
@@ -274,7 +262,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: Set_Variable
       uid: 20e09264-191b-4018-b392-04b751a99277
-      position: {x: -310, y: 10}
+      position: {x: -440, y: -0}
       nodeUIDs:
       - 
       - 09dfef14-acd5-4a05-b59a-4f91484baa8c|0
@@ -287,16 +275,16 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|4aaf2a0a-6354-4bce-b842-c305193d30b2
     - fullName: UnityEngineVector3Array.__ctor__SystemInt32__UnityEngineVector3Array
       uid: 9dce16c7-8cb9-4b8a-b96a-39b7dd9b3f0b
-      position: {x: -710, y: 140}
+      position: {x: -840, y: 120}
       nodeUIDs:
-      - 17221806-01ea-49ac-abf8-f67f9e58aaf6|0
+      - d4a0f09a-9dc3-4a4e-8b9d-0bc5a049c4d7|0
       flowUIDs: []
       nodeValues:
       - unityObjectValue: {fileID: 0}
         stringValue: System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|10
     - fullName: UnityEngineLineRenderer.__get_positionCount__SystemInt32
       uid: d4a0f09a-9dc3-4a4e-8b9d-0bc5a049c4d7
-      position: {x: -1050, y: 140}
+      position: {x: -1180, y: 120}
       nodeUIDs:
       - aaf3e75f-5574-4790-8b3b-272131e9336e|0
       flowUIDs: []
@@ -326,7 +314,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|none
     - fullName: Const_SystemBoolean
       uid: 282e165c-f7e1-4f48-ac66-0caf0eb2ae0a
-      position: {x: 40, y: 1170}
+      position: {x: 580, y: 1490}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -335,7 +323,7 @@ MonoBehaviour:
         stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|True
     - fullName: Set_ReturnValue
       uid: 3973ee95-2edf-462a-bf82-13d1ae9ddb06
-      position: {x: 160, y: 1080}
+      position: {x: 700, y: 1410}
       nodeUIDs:
       - 
       - 282e165c-f7e1-4f48-ac66-0caf0eb2ae0a
@@ -347,7 +335,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: Event_OnOwnershipRequest
       uid: 3cd76e77-e278-4901-82f1-7e5471ca4020
-      position: {x: -250, y: 1080}
+      position: {x: 260, y: 1410}
       nodeUIDs: []
       flowUIDs:
       - 3973ee95-2edf-462a-bf82-13d1ae9ddb06
@@ -374,21 +362,9 @@ MonoBehaviour:
         stringValue: 
       - unityObjectValue: {fileID: 0}
         stringValue: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0.005
-    - fullName: SystemInt32.__op_Subtraction__SystemInt32_SystemInt32__SystemInt32
-      uid: 17221806-01ea-49ac-abf8-f67f9e58aaf6
-      position: {x: -850, y: 140}
-      nodeUIDs:
-      - d4a0f09a-9dc3-4a4e-8b9d-0bc5a049c4d7|0
-      - 
-      flowUIDs: []
-      nodeValues:
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0
     - fullName: Event_Custom
       uid: 88e1f699-c450-46b2-85fd-20b65399ad98
-      position: {x: -770, y: 0}
+      position: {x: -900, y: -0}
       nodeUIDs:
       - 
       flowUIDs:
@@ -398,7 +374,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|OnUpdate
     - fullName: UnityEngineLineRenderer.__GetPositions__UnityEngineVector3Array__SystemInt32
       uid: 09dfef14-acd5-4a05-b59a-4f91484baa8c
-      position: {x: -550, y: 20}
+      position: {x: -680, y: -0}
       nodeUIDs:
       - aaf3e75f-5574-4790-8b3b-272131e9336e|0
       - 9dce16c7-8cb9-4b8a-b96a-39b7dd9b3f0b|0
@@ -659,29 +635,17 @@ MonoBehaviour:
         stringValue: 
     - fullName: Event_Custom
       uid: 4e97a5b1-7ca5-41df-a630-975df12fcc3e
-      position: {x: -160, y: 1380}
+      position: {x: 100, y: 980}
       nodeUIDs:
       - 
       flowUIDs:
-      - 1103ba68-f944-4328-bbc8-e598f3a657c7
+      - 827a4fb5-db4d-49cc-989d-a04344685c73
       nodeValues:
       - unityObjectValue: {fileID: 0}
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|Erase
-    - fullName: UnityEngineGameObject.__SetActive__SystemBoolean__SystemVoid
-      uid: 1103ba68-f944-4328-bbc8-e598f3a657c7
-      position: {x: 60, y: 1380}
-      nodeUIDs:
-      - 
-      - 
-      flowUIDs: []
-      nodeValues:
-      - unityObjectValue: {fileID: 0}
-        stringValue: 
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|False
     - fullName: Event_Custom
       uid: e2347eda-7f95-484f-b0d8-503d9483b02e
-      position: {x: 790, y: 680}
+      position: {x: 620, y: 530}
       nodeUIDs:
       - 
       flowUIDs:
@@ -691,7 +655,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|BakeMesh
     - fullName: UnityEngineLineRenderer.__BakeMesh__UnityEngineMesh_SystemBoolean__SystemVoid
       uid: c5c4268d-e894-4978-bd7b-eb20b8c2a98e
-      position: {x: 1070, y: 700}
+      position: {x: 1000, y: 550}
       nodeUIDs:
       - 9a4f528b-5e20-4df0-8e7d-97a1eb128524|0
       - c93c5d5a-290d-4d29-9f12-62002cdf6093
@@ -710,7 +674,7 @@ MonoBehaviour:
         stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|True
     - fullName: Get_Variable
       uid: c93c5d5a-290d-4d29-9f12-62002cdf6093
-      position: {x: 850, y: 930}
+      position: {x: 680, y: 780}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -721,7 +685,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: Get_Variable
       uid: 7b7dbada-d3ec-4fee-a4e0-82c6a6b64bf2
-      position: {x: 1040, y: 890}
+      position: {x: 960, y: 740}
       nodeUIDs:
       - 7b7dbada-d3ec-4fee-a4e0-82c6a6b64bf2
       flowUIDs: []
@@ -732,7 +696,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: UnityEngineMeshCollider.__set_sharedMesh__UnityEngineMesh__SystemVoid
       uid: 455e89ff-bc54-4a82-a5a8-a90f0258f871
-      position: {x: 1270, y: 880}
+      position: {x: 1280, y: 730}
       nodeUIDs:
       - 7b7dbada-d3ec-4fee-a4e0-82c6a6b64bf2
       - c93c5d5a-290d-4d29-9f12-62002cdf6093
@@ -745,7 +709,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: Get_Variable
       uid: 9a4f528b-5e20-4df0-8e7d-97a1eb128524
-      position: {x: 780, y: 770}
+      position: {x: 600, y: 620}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -770,11 +734,98 @@ MonoBehaviour:
           Version=1.0.0.0, Culture=neutral, PublicKeyToken=null|All
       - unityObjectValue: {fileID: 0}
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|BakeMesh
+    - fullName: Block
+      uid: 1e9abd17-3958-473c-9584-5aa530207f4d
+      position: {x: -300, y: 690}
+      nodeUIDs: []
+      flowUIDs:
+      - cd88b179-20e7-4d23-842d-76f09578142d
+      - dcc2a36f-dc42-4090-a375-0e96144f70f9
+      nodeValues: []
+    - fullName: VRCSDKBaseNetworking.__IsOwner__UnityEngineGameObject__SystemBoolean
+      uid: 203153f1-f39c-4416-a009-4d78609ec798
+      position: {x: 120, y: 1080}
+      nodeUIDs:
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+    - fullName: Branch
+      uid: 827a4fb5-db4d-49cc-989d-a04344685c73
+      position: {x: 320, y: 1000}
+      nodeUIDs:
+      - 203153f1-f39c-4416-a009-4d78609ec798|0
+      flowUIDs:
+      - 0a2391ef-555b-4186-bd37-5ecd94717951
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|False
+    - fullName: Get_Variable
+      uid: f6c166cb-9683-4af6-8333-38ea9102fa78
+      position: {x: 240, y: 1200}
+      nodeUIDs:
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|d4139c3b-f0b7-4103-b844-bc897daa6ec5
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+    - fullName: UnityEngineLineRenderer.__set_positionCount__SystemInt32__SystemVoid
+      uid: 0a2391ef-555b-4186-bd37-5ecd94717951
+      position: {x: 490, y: 1100}
+      nodeUIDs:
+      - f6c166cb-9683-4af6-8333-38ea9102fa78|0
+      - 
+      flowUIDs:
+      - 8be94178-95b9-44ba-8d50-eb18e4e088f5
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0
+    - fullName: VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid
+      uid: 8be94178-95b9-44ba-8d50-eb18e4e088f5
+      position: {x: 690, y: 1100}
+      nodeUIDs:
+      - 
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|OnUpdate
+    - fullName: UnityEngineLineRenderer.__set_enabled__SystemBoolean__SystemVoid
+      uid: dcc2a36f-dc42-4090-a375-0e96144f70f9
+      position: {x: 380, y: 720}
+      nodeUIDs:
+      - 26b001e6-406f-4d3e-bd2c-0a5bb2e511d6|0
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|True
+    - fullName: UnityEngineLineRenderer.__set_enabled__SystemBoolean__SystemVoid
+      uid: 0231cabc-9956-4cfb-920f-08e39ec5eda3
+      position: {x: -100, y: 90}
+      nodeUIDs:
+      - aaf3e75f-5574-4790-8b3b-272131e9336e|0
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|True
     updateOrder: 0
   graphElementData:
   - type: 2
     uid: 582b9bc5-eaab-4254-9672-6dd07de9ef1c
-    jsonData: '{"uid":"582b9bc5-eaab-4254-9672-6dd07de9ef1c","layout":{"serializedVersion":"2","x":-530.0,"y":630.0,"width":1058.0,"height":332.0},"containedElements":["b08ad0aa-7980-402b-b9c3-9b9ab385febc","cd88b179-20e7-4d23-842d-76f09578142d","26b001e6-406f-4d3e-bd2c-0a5bb2e511d6","927d1cb8-d331-49d9-9531-c7bfe4b9c796","e11f63e2-0222-48dc-b22c-d1b58d2ddba0","f61dd935-f54c-41bf-b4c1-7f819e8ede51"],"title":"Set
+    jsonData: '{"uid":"582b9bc5-eaab-4254-9672-6dd07de9ef1c","layout":{"serializedVersion":"2","x":-560.0,"y":460.0,"width":1114.0,"height":412.0},"containedElements":["b08ad0aa-7980-402b-b9c3-9b9ab385febc","cd88b179-20e7-4d23-842d-76f09578142d","26b001e6-406f-4d3e-bd2c-0a5bb2e511d6","927d1cb8-d331-49d9-9531-c7bfe4b9c796","e11f63e2-0222-48dc-b22c-d1b58d2ddba0","f61dd935-f54c-41bf-b4c1-7f819e8ede51","1e9abd17-3958-473c-9584-5aa530207f4d","dcc2a36f-dc42-4090-a375-0e96144f70f9"],"title":"Set
       LinePositions from Synced Data","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: ee8529df-6d2b-47b0-aaeb-a2c9f73e2895
@@ -782,7 +833,7 @@ MonoBehaviour:
       Update Points Array from LineRenderer and Bake the Mesh Collider","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: cd33cf70-0bc3-43db-ac00-0b5eaea3e7c1
-    jsonData: '{"uid":"cd33cf70-0bc3-43db-ac00-0b5eaea3e7c1","layout":{"serializedVersion":"2","x":-280.0,"y":1020.0,"width":619.0,"height":262.0},"containedElements":["3cd76e77-e278-4901-82f1-7e5471ca4020","3973ee95-2edf-462a-bf82-13d1ae9ddb06","282e165c-f7e1-4f48-ac66-0caf0eb2ae0a"],"title":"Allow
+    jsonData: '{"uid":"cd33cf70-0bc3-43db-ac00-0b5eaea3e7c1","layout":{"serializedVersion":"2","x":240.0,"y":1340.0,"width":649.0,"height":255.0},"containedElements":["3cd76e77-e278-4901-82f1-7e5471ca4020","3973ee95-2edf-462a-bf82-13d1ae9ddb06","282e165c-f7e1-4f48-ac66-0caf0eb2ae0a"],"title":"Allow
       Ownership Changes","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: 019e6437-e965-421e-b090-6c82a78cb746
@@ -804,17 +855,17 @@ MonoBehaviour:
       LineMesh","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: e1f1b054-6654-41d6-8b91-4ef815c32248
-    jsonData: '{"uid":"e1f1b054-6654-41d6-8b91-4ef815c32248","layout":{"serializedVersion":"2","x":-1320.0,"y":-60.0,"width":1372.0,"height":336.0},"containedElements":["aaf3e75f-5574-4790-8b3b-272131e9336e","d4a0f09a-9dc3-4a4e-8b9d-0bc5a049c4d7","17221806-01ea-49ac-abf8-f67f9e58aaf6","9dce16c7-8cb9-4b8a-b96a-39b7dd9b3f0b","88e1f699-c450-46b2-85fd-20b65399ad98","09dfef14-acd5-4a05-b59a-4f91484baa8c","20e09264-191b-4018-b392-04b751a99277","c6cd907a-9fa4-483b-8d26-a12cc00369d1"],"title":"OnUpdate
+    jsonData: '{"uid":"e1f1b054-6654-41d6-8b91-4ef815c32248","layout":{"serializedVersion":"2","x":-1450.0,"y":-70.0,"width":1514.0,"height":312.0},"containedElements":["aaf3e75f-5574-4790-8b3b-272131e9336e","d4a0f09a-9dc3-4a4e-8b9d-0bc5a049c4d7","17221806-01ea-49ac-abf8-f67f9e58aaf6","9dce16c7-8cb9-4b8a-b96a-39b7dd9b3f0b","88e1f699-c450-46b2-85fd-20b65399ad98","09dfef14-acd5-4a05-b59a-4f91484baa8c","20e09264-191b-4018-b392-04b751a99277","c6cd907a-9fa4-483b-8d26-a12cc00369d1","94300a0f-fffd-4d63-b693-810df22d8ac2","89634880-af43-48e3-8eee-9fa0ebd03d8d","74b8dd8c-4933-4348-b49f-13467781dfbc","bfa17618-2d59-4bcb-8bcc-fdc8f4ddf791","556f7a86-baf5-4126-9a0b-8cac1959e9d7","6df87277-2773-4fc1-8759-3301318e7dea","900f438c-af81-4909-9f1a-3ce97afdd50f","d6ec34e4-8d76-45ea-b7b5-2458c4ab5a6c","cf073497-7524-4f3d-b6ab-5de7b52a95a7","19692ffd-f76d-4f0b-b4c7-89376dd539c8","6293d738-3475-47bd-a84c-5b56d13d31ab","0231cabc-9956-4cfb-920f-08e39ec5eda3"],"title":"OnUpdate
       event, set points from current line positions","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: 6c9a2647-f553-4369-b493-fccf6e7894f7
-    jsonData: '{"uid":"6c9a2647-f553-4369-b493-fccf6e7894f7","layout":{"serializedVersion":"2","x":-180.0,"y":1320.0,"width":409.0,"height":220.0},"containedElements":["4e97a5b1-7ca5-41df-a630-975df12fcc3e","1103ba68-f944-4328-bbc8-e598f3a657c7"],"title":"Network
+    jsonData: '{"uid":"6c9a2647-f553-4369-b493-fccf6e7894f7","layout":{"serializedVersion":"2","x":80.0,"y":910.0,"width":915.0,"height":395.0},"containedElements":["4e97a5b1-7ca5-41df-a630-975df12fcc3e","1103ba68-f944-4328-bbc8-e598f3a657c7","827a4fb5-db4d-49cc-989d-a04344685c73","203153f1-f39c-4416-a009-4d78609ec798","a1787403-6977-4099-a8ef-71952fbe3225","4f130d6f-b2d7-4a21-8821-2e0148f966f1","61cf5e66-4e79-4e97-9063-336a40752b2c","7f056d49-2797-4726-9a26-7e0b712ac36a","49ec468a-beeb-4154-a891-06ea83e5cfa5","f6c166cb-9683-4af6-8333-38ea9102fa78","0a2391ef-555b-4186-bd37-5ecd94717951","8be94178-95b9-44ba-8d50-eb18e4e088f5"],"title":"Network
       Erase Event","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: b0e7eec9-ad53-4ae1-8b99-67cc560e3190
-    jsonData: '{"uid":"b0e7eec9-ad53-4ae1-8b99-67cc560e3190","layout":{"serializedVersion":"2","x":760.0,"y":620.0,"width":715.0,"height":422.0},"containedElements":["c5c4268d-e894-4978-bd7b-eb20b8c2a98e","e2347eda-7f95-484f-b0d8-503d9483b02e","9a4f528b-5e20-4df0-8e7d-97a1eb128524","7b7dbada-d3ec-4fee-a4e0-82c6a6b64bf2","455e89ff-bc54-4a82-a5a8-a90f0258f871","c93c5d5a-290d-4d29-9f12-62002cdf6093"],"title":"BakeMesh","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
+    jsonData: '{"uid":"b0e7eec9-ad53-4ae1-8b99-67cc560e3190","layout":{"serializedVersion":"2","x":580.0,"y":460.0,"width":905.0,"height":424.0},"containedElements":["c5c4268d-e894-4978-bd7b-eb20b8c2a98e","e2347eda-7f95-484f-b0d8-503d9483b02e","9a4f528b-5e20-4df0-8e7d-97a1eb128524","7b7dbada-d3ec-4fee-a4e0-82c6a6b64bf2","455e89ff-bc54-4a82-a5a8-a90f0258f871","c93c5d5a-290d-4d29-9f12-62002cdf6093"],"title":"BakeMesh","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   viewTransform:
-    position: {x: 30.489702, y: 557.9988}
-    scale: 0.8695652
+    position: {x: 820.1543, y: 600.60333}
+    scale: 0.7561437
   version: 1.0.0
   showAssembly: 0

--- a/Assets/_WorldJam1/Drawing/UdonPrograms/PenLineColor.asset
+++ b/Assets/_WorldJam1/Drawing/UdonPrograms/PenLineColor.asset
@@ -22,38 +22,41 @@ MonoBehaviour:
     null\r\n    value_0: %SystemInt32, null\r\n    instance_4: %UnityEngineVector3Array,
     null\r\n    instance_5: %UnityEngineLineRenderer, null\r\n    positions_0: %UnityEngineVector3Array,
     null\r\n    instance_6: %VRCUdonUdonBehaviour, this\r\n    eventName_2: %SystemString,
-    null\r\n    Boolean_0: %SystemBoolean, null\r\n    Int32_3: %SystemInt32, null\r\n
-    \   instance_7: %UnityEngineLineRenderer, null\r\n    positions_1: %UnityEngineVector3Array,
-    null\r\n    Int32_0: %SystemInt32, null\r\n    Int32_1: %SystemInt32, null\r\n
-    \   Int32_2: %SystemInt32, null\r\n    instance_8: %UnityEngineLineRenderer, null\r\n
-    \   instance_9: %VRCUdonUdonBehaviour, this\r\n    instance_A: %VRCUdonUdonBehaviour,
-    this\r\n    eventName_3: %SystemString, null\r\n    object_0: %SystemObject, null\r\n
-    \   Type_0: %SystemType, null\r\n    result_0: %SystemBoolean, null\r\n    instance_B:
+    null\r\n    instance_7: %UnityEngineLineRenderer, null\r\n    value_1: %SystemBoolean,
+    null\r\n    Boolean_0: %SystemBoolean, null\r\n    Int32_1: %SystemInt32, null\r\n
+    \   instance_8: %UnityEngineLineRenderer, null\r\n    positions_1: %UnityEngineVector3Array,
+    null\r\n    Int32_0: %SystemInt32, null\r\n    instance_9: %UnityEngineLineRenderer,
+    null\r\n    instance_A: %VRCUdonUdonBehaviour, this\r\n    eventName_3: %SystemString,
+    null\r\n    instance_B: %VRCUdonUdonBehaviour, this\r\n    instance_C: %UnityEngineLineRenderer,
+    null\r\n    value_2: %SystemBoolean, null\r\n    object_0: %SystemObject, null\r\n
+    \   Type_0: %SystemType, null\r\n    result_0: %SystemBoolean, null\r\n    instance_D:
     %UnityEngineGameObject, this\r\n    type_0: %SystemType, null\r\n    Type_1: %SystemType,
     null\r\n    message_0: %SystemObject, null\r\n    format_0: %SystemString, null\r\n
     \   arg0_0: %SystemObject, null\r\n    arg1_0: %SystemObject, null\r\n    Type_2:
     %SystemType, null\r\n    object_1: %SystemObject, null\r\n    Type_3: %SystemType,
-    null\r\n    result_1: %SystemBoolean, null\r\n    instance_D: %UnityEngineGameObject,
+    null\r\n    result_1: %SystemBoolean, null\r\n    instance_F: %UnityEngineGameObject,
     this\r\n    type_1: %SystemType, null\r\n    Type_4: %SystemType, null\r\n    message_1:
     %SystemObject, null\r\n    format_1: %SystemString, null\r\n    arg0_1: %SystemObject,
-    null\r\n    arg1_1: %SystemObject, null\r\n    Type_5: %SystemType, null\r\n    instance_C:
+    null\r\n    arg1_1: %SystemObject, null\r\n    Type_5: %SystemType, null\r\n    instance_E:
     %UnityEngineGameObject, this\r\n    GameObject_0: %UnityEngineGameObject, this\r\n
     \   Boolean_1: %SystemBoolean, null\r\n    Color_0: %UnityEngineColor, null\r\n
-    \   Color_1: %UnityEngineColor, null\r\n    instance_E: %VRCUdonUdonBehaviour,
-    this\r\n    eventName_4: %SystemString, null\r\n    instance_F: %UnityEngineLineRenderer,
-    null\r\n    value_1: %UnityEngineColor, null\r\n    instance_10: %UnityEngineLineRenderer,
-    null\r\n    value_2: %UnityEngineColor, null\r\n    H_1: %SystemSingle, null\r\n
+    \   Color_1: %UnityEngineColor, null\r\n    instance_10: %VRCUdonUdonBehaviour,
+    this\r\n    eventName_4: %SystemString, null\r\n    instance_11: %UnityEngineLineRenderer,
+    null\r\n    value_3: %UnityEngineColor, null\r\n    instance_12: %UnityEngineLineRenderer,
+    null\r\n    value_4: %UnityEngineColor, null\r\n    H_1: %SystemSingle, null\r\n
     \   S_1: %SystemSingle, null\r\n    V_1: %SystemSingle, null\r\n    Single_0:
     %SystemSingle, null\r\n    Single_1: %SystemSingle, null\r\n    rgbColor_0: %UnityEngineColor,
     null\r\n    H_0: %SystemSingle, null\r\n    S_0: %SystemSingle, null\r\n    V_0:
-    %SystemSingle, null\r\n    instance_11: %UnityEngineGameObject, this\r\n    value_3:
-    %SystemBoolean, null\r\n    instance_12: %UnityEngineLineRenderer, null\r\n    mesh_0:
-    %UnityEngineMesh, null\r\n    useTransform_0: %SystemBoolean, null\r\n    instance_13:
-    %UnityEngineMeshCollider, null\r\n    value_4: %UnityEngineMesh, null\r\n    isDown:
-    %SystemBoolean, null\r\n    points: %UnityEngineVector3Array, null\r\n    lineRenderer:
-    %UnityEngineLineRenderer, null\r\n    __returnValue: %SystemObject, null\r\n    lineMesh:
-    %UnityEngineMesh, null\r\n    lineCollider: %UnityEngineMeshCollider, null\r\n
-    \   color: %UnityEngineColor, null\r\n    lastColor: %UnityEngineColor, null\r\n\r\n.data_end\r\n\r\n.code_start\r\n\r\n
+    %SystemSingle, null\r\n    instance_13: %UnityEngineLineRenderer, null\r\n    mesh_0:
+    %UnityEngineMesh, null\r\n    useTransform_0: %SystemBoolean, null\r\n    instance_14:
+    %UnityEngineMeshCollider, null\r\n    value_5: %UnityEngineMesh, null\r\n    Boolean_2:
+    %SystemBoolean, null\r\n    obj_0: %UnityEngineGameObject, this\r\n    instance_15:
+    %UnityEngineLineRenderer, null\r\n    value_6: %SystemInt32, null\r\n    instance_16:
+    %VRCUdonUdonBehaviour, this\r\n    eventName_5: %SystemString, null\r\n    points:
+    %UnityEngineVector3Array, null\r\n    lineRenderer: %UnityEngineLineRenderer,
+    null\r\n    __returnValue: %SystemObject, null\r\n    lineMesh: %UnityEngineMesh,
+    null\r\n    lineCollider: %UnityEngineMeshCollider, null\r\n    color: %UnityEngineColor,
+    null\r\n    lastColor: %UnityEngineColor, null\r\n\r\n.data_end\r\n\r\n.code_start\r\n\r\n
     \   .export OnFinish\r\n    \r\n    OnFinish:\r\n    \r\n        PUSH, lineRenderer\r\n
     \       PUSH, instance_0\r\n        COPY\r\n        PUSH, instance_0\r\n        PUSH,
     tolerance_0\r\n        EXTERN, \"UnityEngineLineRenderer.__Simplify__SystemSingle__SystemVoid\"\r\n
@@ -70,48 +73,51 @@ MonoBehaviour:
     points\r\n        PUSH, positions_0\r\n        COPY\r\n        PUSH, instance_5\r\n
     \       PUSH, positions_0\r\n        EXTERN, \"UnityEngineLineRenderer.__SetPositions__UnityEngineVector3Array__SystemVoid\"\r\n
     \       PUSH, instance_6\r\n        PUSH, eventName_2\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid\"\r\n
+    \       PUSH, lineRenderer\r\n        PUSH, instance_7\r\n        COPY\r\n        PUSH,
+    instance_7\r\n        PUSH, value_1\r\n        EXTERN, \"UnityEngineLineRenderer.__set_enabled__SystemBoolean__SystemVoid\"\r\n
     \       JUMP, 0xFFFFFFFC\r\n    \r\n    .export _onOwnershipRequest\r\n    \r\n
     \   _onOwnershipRequest:\r\n    \r\n        PUSH, Boolean_0\r\n        PUSH, __returnValue\r\n
     \       COPY\r\n        JUMP, 0xFFFFFFFC\r\n    \r\n    .export OnUpdate\r\n    \r\n
-    \   OnUpdate:\r\n    \r\n        PUSH, lineRenderer\r\n        PUSH, instance_7\r\n
-    \       COPY\r\n        PUSH, lineRenderer\r\n        PUSH, instance_8\r\n        COPY\r\n
-    \       PUSH, instance_8\r\n        PUSH, Int32_1\r\n        EXTERN, \"UnityEngineLineRenderer.__get_positionCount__SystemInt32\"\r\n
-    \       PUSH, Int32_1\r\n        PUSH, Int32_2\r\n        PUSH, Int32_0\r\n        EXTERN,
-    \"SystemInt32.__op_Subtraction__SystemInt32_SystemInt32__SystemInt32\"\r\n        PUSH,
-    Int32_0\r\n        PUSH, positions_1\r\n        EXTERN, \"UnityEngineVector3Array.__ctor__SystemInt32__UnityEngineVector3Array\"\r\n
-    \       PUSH, instance_7\r\n        PUSH, positions_1\r\n        PUSH, Int32_3\r\n
+    \   OnUpdate:\r\n    \r\n        PUSH, lineRenderer\r\n        PUSH, instance_8\r\n
+    \       COPY\r\n        PUSH, lineRenderer\r\n        PUSH, instance_9\r\n        COPY\r\n
+    \       PUSH, instance_9\r\n        PUSH, Int32_0\r\n        EXTERN, \"UnityEngineLineRenderer.__get_positionCount__SystemInt32\"\r\n
+    \       PUSH, Int32_0\r\n        PUSH, positions_1\r\n        EXTERN, \"UnityEngineVector3Array.__ctor__SystemInt32__UnityEngineVector3Array\"\r\n
+    \       PUSH, instance_8\r\n        PUSH, positions_1\r\n        PUSH, Int32_1\r\n
     \       EXTERN, \"UnityEngineLineRenderer.__GetPositions__UnityEngineVector3Array__SystemInt32\"\r\n
-    \       PUSH, lineRenderer\r\n        PUSH, instance_7\r\n        COPY\r\n        PUSH,
-    lineRenderer\r\n        PUSH, instance_8\r\n        COPY\r\n        PUSH, positions_1\r\n
+    \       PUSH, lineRenderer\r\n        PUSH, instance_8\r\n        COPY\r\n        PUSH,
+    lineRenderer\r\n        PUSH, instance_9\r\n        COPY\r\n        PUSH, positions_1\r\n
     \       PUSH, points\r\n        COPY\r\n        PUSH, positions_1\r\n        PUSH,
-    points\r\n        COPY\r\n        PUSH, instance_9\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__RequestSerialization__SystemVoid\"\r\n
-    \       PUSH, instance_A\r\n        PUSH, eventName_3\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid\"\r\n
+    points\r\n        COPY\r\n        PUSH, instance_A\r\n        PUSH, eventName_3\r\n
+    \       EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid\"\r\n
+    \       PUSH, instance_B\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__RequestSerialization__SystemVoid\"\r\n
+    \       PUSH, lineRenderer\r\n        PUSH, instance_C\r\n        COPY\r\n        PUSH,
+    instance_C\r\n        PUSH, value_2\r\n        EXTERN, \"UnityEngineLineRenderer.__set_enabled__SystemBoolean__SystemVoid\"\r\n
     \       JUMP, 0xFFFFFFFC\r\n    \r\n    .export _start\r\n    \r\n    _start:\r\n
-    \   \r\n        PUSH, GameObject_0\r\n        PUSH, instance_B\r\n        COPY\r\n
+    \   \r\n        PUSH, GameObject_0\r\n        PUSH, instance_D\r\n        COPY\r\n
     \       PUSH, Type_0\r\n        PUSH, type_0\r\n        COPY\r\n        PUSH,
-    instance_B\r\n        PUSH, type_0\r\n        PUSH, object_0\r\n        EXTERN,
+    instance_D\r\n        PUSH, type_0\r\n        PUSH, object_0\r\n        EXTERN,
     \"UnityEngineGameObject.__GetComponent__SystemType__UnityEngineComponent\"\r\n
     \       PUSH, object_0\r\n        PUSH, result_0\r\n        EXTERN, \"VRCSDKBaseUtilities.__IsValid__SystemObject__SystemBoolean\"\r\n
-    \       PUSH, result_0\r\n        JUMP_IF_FALSE, 0x00000320\r\n        PUSH, GameObject_0\r\n
-    \       PUSH, instance_B\r\n        COPY\r\n        PUSH, Type_1\r\n        PUSH,
+    \       PUSH, result_0\r\n        JUMP_IF_FALSE, 0x00000358\r\n        PUSH, GameObject_0\r\n
+    \       PUSH, instance_D\r\n        COPY\r\n        PUSH, Type_1\r\n        PUSH,
     type_0\r\n        COPY\r\n        PUSH, object_0\r\n        PUSH, lineRenderer\r\n
     \       COPY\r\n        PUSH, object_0\r\n        PUSH, lineRenderer\r\n        COPY\r\n
-    \       JUMP, 0x00000398\r\n        PUSH, Type_2\r\n        PUSH, arg0_0\r\n        COPY\r\n
-    \       PUSH, GameObject_0\r\n        PUSH, instance_C\r\n        COPY\r\n        PUSH,
-    instance_C\r\n        PUSH, arg1_0\r\n        EXTERN, \"UnityEngineGameObject.__get_name__SystemString\"\r\n
+    \       JUMP, 0x000003D0\r\n        PUSH, Type_2\r\n        PUSH, arg0_0\r\n        COPY\r\n
+    \       PUSH, GameObject_0\r\n        PUSH, instance_E\r\n        COPY\r\n        PUSH,
+    instance_E\r\n        PUSH, arg1_0\r\n        EXTERN, \"UnityEngineGameObject.__get_name__SystemString\"\r\n
     \       PUSH, format_0\r\n        PUSH, arg0_0\r\n        PUSH, arg1_0\r\n        PUSH,
     message_0\r\n        EXTERN, \"SystemString.__Format__SystemString_SystemObject_SystemObject__SystemString\"\r\n
     \       PUSH, message_0\r\n        EXTERN, \"UnityEngineDebug.__Log__SystemObject__SystemVoid\"\r\n
-    \       PUSH, GameObject_0\r\n        PUSH, instance_D\r\n        COPY\r\n        PUSH,
-    Type_3\r\n        PUSH, type_1\r\n        COPY\r\n        PUSH, instance_D\r\n
+    \       PUSH, GameObject_0\r\n        PUSH, instance_F\r\n        COPY\r\n        PUSH,
+    Type_3\r\n        PUSH, type_1\r\n        COPY\r\n        PUSH, instance_F\r\n
     \       PUSH, type_1\r\n        PUSH, object_1\r\n        EXTERN, \"UnityEngineGameObject.__GetComponent__SystemType__UnityEngineComponent\"\r\n
     \       PUSH, object_1\r\n        PUSH, result_1\r\n        EXTERN, \"VRCSDKBaseUtilities.__IsValid__SystemObject__SystemBoolean\"\r\n
-    \       PUSH, result_1\r\n        JUMP_IF_FALSE, 0x00000460\r\n        PUSH, GameObject_0\r\n
-    \       PUSH, instance_D\r\n        COPY\r\n        PUSH, Type_4\r\n        PUSH,
+    \       PUSH, result_1\r\n        JUMP_IF_FALSE, 0x00000498\r\n        PUSH, GameObject_0\r\n
+    \       PUSH, instance_F\r\n        COPY\r\n        PUSH, Type_4\r\n        PUSH,
     type_1\r\n        COPY\r\n        PUSH, object_1\r\n        PUSH, lineCollider\r\n
     \       COPY\r\n        PUSH, object_1\r\n        PUSH, lineCollider\r\n        COPY\r\n
-    \       JUMP, 0x000004D4\r\n        PUSH, Type_5\r\n        PUSH, arg0_1\r\n        COPY\r\n
-    \       PUSH, GameObject_0\r\n        PUSH, instance_C\r\n        COPY\r\n        PUSH,
+    \       JUMP, 0x0000050C\r\n        PUSH, Type_5\r\n        PUSH, arg0_1\r\n        COPY\r\n
+    \       PUSH, GameObject_0\r\n        PUSH, instance_E\r\n        COPY\r\n        PUSH,
     arg1_0\r\n        PUSH, arg1_1\r\n        COPY\r\n        PUSH, format_1\r\n        PUSH,
     arg0_1\r\n        PUSH, arg1_0\r\n        PUSH, message_1\r\n        EXTERN, \"SystemString.__Format__SystemString_SystemObject_SystemObject__SystemString\"\r\n
     \       PUSH, message_1\r\n        EXTERN, \"UnityEngineDebug.__Log__SystemObject__SystemVoid\"\r\n
@@ -119,58 +125,41 @@ MonoBehaviour:
     \       JUMP, 0xFFFFFFFC\r\n    \r\n    .export CheckColor\r\n    \r\n    CheckColor:\r\n
     \   \r\n        PUSH, color\r\n        PUSH, lastColor\r\n        PUSH, Boolean_1\r\n
     \       EXTERN, \"UnityEngineColor.__op_Inequality__UnityEngineColor_UnityEngineColor__SystemBoolean\"\r\n
-    \       PUSH, Boolean_1\r\n        JUMP_IF_FALSE, 0x0000053C\r\n        PUSH,
-    instance_E\r\n        PUSH, eventName_4\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid\"\r\n
-    \       JUMP, 0x0000053C\r\n        JUMP, 0xFFFFFFFC\r\n    \r\n    .export UpdateLineColor\r\n
+    \       PUSH, Boolean_1\r\n        JUMP_IF_FALSE, 0x00000574\r\n        PUSH,
+    instance_10\r\n        PUSH, eventName_4\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid\"\r\n
+    \       JUMP, 0x00000574\r\n        JUMP, 0xFFFFFFFC\r\n    \r\n    .export UpdateLineColor\r\n
     \   \r\n    UpdateLineColor:\r\n    \r\n        PUSH, lineRenderer\r\n        PUSH,
-    instance_F\r\n        COPY\r\n        PUSH, instance_F\r\n        PUSH, color\r\n
+    instance_11\r\n        COPY\r\n        PUSH, instance_11\r\n        PUSH, color\r\n
     \       EXTERN, \"UnityEngineLineRenderer.__set_startColor__UnityEngineColor__SystemVoid\"\r\n
     \       PUSH, color\r\n        PUSH, H_0\r\n        PUSH, S_0\r\n        PUSH,
     V_0\r\n        EXTERN, \"UnityEngineColor.__RGBToHSV__UnityEngineColor_SystemSingleRef_SystemSingleRef_SystemSingleRef__SystemVoid\"\r\n
-    \       PUSH, lineRenderer\r\n        PUSH, instance_10\r\n        COPY\r\n        PUSH,
+    \       PUSH, lineRenderer\r\n        PUSH, instance_12\r\n        COPY\r\n        PUSH,
     H_0\r\n        PUSH, Single_0\r\n        COPY\r\n        PUSH, H_0\r\n        PUSH,
     Single_1\r\n        PUSH, H_1\r\n        EXTERN, \"SystemSingle.__op_Subtraction__SystemSingle_SystemSingle__SystemSingle\"\r\n
-    \       PUSH, S_0\r\n        PUSH, S_1\r\n        COPY\r\n        PUSH, H_1\r\n
-    \       PUSH, S_0\r\n        PUSH, V_1\r\n        PUSH, value_2\r\n        EXTERN,
-    \"UnityEngineColor.__HSVToRGB__SystemSingle_SystemSingle_SystemSingle__UnityEngineColor\"\r\n
-    \       PUSH, instance_10\r\n        PUSH, value_2\r\n        EXTERN, \"UnityEngineLineRenderer.__set_endColor__UnityEngineColor__SystemVoid\"\r\n
+    \       PUSH, S_0\r\n        PUSH, S_1\r\n        COPY\r\n        PUSH, V_0\r\n
+    \       PUSH, V_1\r\n        COPY\r\n        PUSH, H_1\r\n        PUSH, S_0\r\n
+    \       PUSH, V_0\r\n        PUSH, value_4\r\n        EXTERN, \"UnityEngineColor.__HSVToRGB__SystemSingle_SystemSingle_SystemSingle__UnityEngineColor\"\r\n
+    \       PUSH, instance_12\r\n        PUSH, value_4\r\n        EXTERN, \"UnityEngineLineRenderer.__set_endColor__UnityEngineColor__SystemVoid\"\r\n
+    \       JUMP, 0xFFFFFFFC\r\n    \r\n    .export BakeMesh\r\n    \r\n    BakeMesh:\r\n
+    \   \r\n        PUSH, lineRenderer\r\n        PUSH, instance_13\r\n        COPY\r\n
+    \       PUSH, lineMesh\r\n        PUSH, mesh_0\r\n        COPY\r\n        PUSH,
+    instance_13\r\n        PUSH, mesh_0\r\n        PUSH, useTransform_0\r\n        EXTERN,
+    \"UnityEngineLineRenderer.__BakeMesh__UnityEngineMesh_SystemBoolean__SystemVoid\"\r\n
+    \       PUSH, lineCollider\r\n        PUSH, instance_14\r\n        COPY\r\n        PUSH,
+    lineMesh\r\n        PUSH, value_5\r\n        COPY\r\n        PUSH, instance_14\r\n
+    \       PUSH, value_5\r\n        EXTERN, \"UnityEngineMeshCollider.__set_sharedMesh__UnityEngineMesh__SystemVoid\"\r\n
     \       JUMP, 0xFFFFFFFC\r\n    \r\n    .export Erase\r\n    \r\n    Erase:\r\n
-    \   \r\n        PUSH, instance_11\r\n        PUSH, value_3\r\n        EXTERN,
-    \"UnityEngineGameObject.__SetActive__SystemBoolean__SystemVoid\"\r\n        JUMP,
-    0xFFFFFFFC\r\n    \r\n    .export BakeMesh\r\n    \r\n    BakeMesh:\r\n    \r\n
-    \       PUSH, lineRenderer\r\n        PUSH, instance_12\r\n        COPY\r\n        PUSH,
-    lineMesh\r\n        PUSH, mesh_0\r\n        COPY\r\n        PUSH, instance_12\r\n
-    \       PUSH, mesh_0\r\n        PUSH, useTransform_0\r\n        EXTERN, \"UnityEngineLineRenderer.__BakeMesh__UnityEngineMesh_SystemBoolean__SystemVoid\"\r\n
-    \       PUSH, lineCollider\r\n        PUSH, instance_13\r\n        COPY\r\n        PUSH,
-    lineMesh\r\n        PUSH, value_4\r\n        COPY\r\n        PUSH, instance_13\r\n
-    \       PUSH, value_4\r\n        EXTERN, \"UnityEngineMeshCollider.__set_sharedMesh__UnityEngineMesh__SystemVoid\"\r\n
-    \       JUMP, 0xFFFFFFFC\r\n    \r\n\r\n.code_end\r\n"
+    \   \r\n        PUSH, obj_0\r\n        PUSH, Boolean_2\r\n        EXTERN, \"VRCSDKBaseNetworking.__IsOwner__UnityEngineGameObject__SystemBoolean\"\r\n
+    \       PUSH, Boolean_2\r\n        JUMP_IF_FALSE, 0x0000078C\r\n        PUSH,
+    lineRenderer\r\n        PUSH, instance_15\r\n        COPY\r\n        PUSH, instance_15\r\n
+    \       PUSH, value_6\r\n        EXTERN, \"UnityEngineLineRenderer.__set_positionCount__SystemInt32__SystemVoid\"\r\n
+    \       PUSH, instance_16\r\n        PUSH, eventName_5\r\n        EXTERN, \"VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid\"\r\n
+    \       JUMP, 0x0000078C\r\n        JUMP, 0xFFFFFFFC\r\n    \r\n\r\n.code_end\r\n"
   assemblyError: 
   graphData:
     name: 
     description: 
     nodes:
-    - fullName: Variable_SystemBoolean
-      uid: 6e9852e8-4f32-4aae-b5d7-3c56b4e80462
-      position: {x: 0, y: 0}
-      nodeUIDs:
-      - 
-      - 
-      - 
-      - 
-      - 
-      flowUIDs: []
-      nodeValues:
-      - unityObjectValue: {fileID: 0}
-        stringValue: 
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|isDown
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|False
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|False
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|none
     - fullName: Event_Custom
       uid: dde4f88a-7917-4bae-b604-e70188cb63da
       position: {x: 110, y: -0}
@@ -226,23 +215,13 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|none
     - fullName: Get_Variable
       uid: aaf3e75f-5574-4790-8b3b-272131e9336e
-      position: {x: -1290, y: 50}
+      position: {x: -1220, y: -10}
       nodeUIDs:
       - 
       flowUIDs: []
       nodeValues:
       - unityObjectValue: {fileID: 0}
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|d4139c3b-f0b7-4103-b844-bc897daa6ec5
-    - fullName: VRCUdonCommonInterfacesIUdonEventReceiver.__RequestSerialization__SystemVoid
-      uid: c6cd907a-9fa4-483b-8d26-a12cc00369d1
-      position: {x: -170, y: -0}
-      nodeUIDs:
-      - 
-      flowUIDs:
-      - 
-      nodeValues:
-      - unityObjectValue: {fileID: 0}
-        stringValue: 
     - fullName: Event_OnDeserialization
       uid: 927d1cb8-d331-49d9-9531-c7bfe4b9c796
       position: {x: -1200, y: 550}
@@ -283,7 +262,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: UnityEngineLineRenderer.__set_positionCount__SystemInt32__SystemVoid
       uid: cd88b179-20e7-4d23-842d-76f09578142d
-      position: {x: -480, y: 570}
+      position: {x: -490, y: 560}
       nodeUIDs:
       - 26b001e6-406f-4d3e-bd2c-0a5bb2e511d6|0
       - b08ad0aa-7980-402b-b9c3-9b9ab385febc|0
@@ -305,12 +284,12 @@ MonoBehaviour:
         stringValue: 
     - fullName: Set_Variable
       uid: 20e09264-191b-4018-b392-04b751a99277
-      position: {x: -310, y: 0}
+      position: {x: -240, y: -60}
       nodeUIDs:
       - 
       - 09dfef14-acd5-4a05-b59a-4f91484baa8c|0
       flowUIDs:
-      - c6cd907a-9fa4-483b-8d26-a12cc00369d1
+      - 
       nodeValues:
       - unityObjectValue: {fileID: 0}
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|4aaf2a0a-6354-4bce-b842-c305193d30b2
@@ -318,16 +297,16 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|4aaf2a0a-6354-4bce-b842-c305193d30b2
     - fullName: UnityEngineVector3Array.__ctor__SystemInt32__UnityEngineVector3Array
       uid: 9dce16c7-8cb9-4b8a-b96a-39b7dd9b3f0b
-      position: {x: -710, y: 140}
+      position: {x: -640, y: 80}
       nodeUIDs:
-      - 17221806-01ea-49ac-abf8-f67f9e58aaf6|0
+      - d4a0f09a-9dc3-4a4e-8b9d-0bc5a049c4d7|0
       flowUIDs: []
       nodeValues:
       - unityObjectValue: {fileID: 0}
         stringValue: System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|10
     - fullName: UnityEngineLineRenderer.__get_positionCount__SystemInt32
       uid: d4a0f09a-9dc3-4a4e-8b9d-0bc5a049c4d7
-      position: {x: -1050, y: 140}
+      position: {x: -980, y: 80}
       nodeUIDs:
       - aaf3e75f-5574-4790-8b3b-272131e9336e|0
       flowUIDs: []
@@ -357,7 +336,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|none
     - fullName: Const_SystemBoolean
       uid: 282e165c-f7e1-4f48-ac66-0caf0eb2ae0a
-      position: {x: 420, y: 710}
+      position: {x: 110, y: 1550}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -366,7 +345,7 @@ MonoBehaviour:
         stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|True
     - fullName: Set_ReturnValue
       uid: 3973ee95-2edf-462a-bf82-13d1ae9ddb06
-      position: {x: 540, y: 620}
+      position: {x: 220, y: 1460}
       nodeUIDs:
       - 
       - 282e165c-f7e1-4f48-ac66-0caf0eb2ae0a
@@ -378,7 +357,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: Event_OnOwnershipRequest
       uid: 3cd76e77-e278-4901-82f1-7e5471ca4020
-      position: {x: 110, y: 620}
+      position: {x: -200, y: 1460}
       nodeUIDs: []
       flowUIDs:
       - 3973ee95-2edf-462a-bf82-13d1ae9ddb06
@@ -405,21 +384,9 @@ MonoBehaviour:
         stringValue: 
       - unityObjectValue: {fileID: 0}
         stringValue: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0.005
-    - fullName: SystemInt32.__op_Subtraction__SystemInt32_SystemInt32__SystemInt32
-      uid: 17221806-01ea-49ac-abf8-f67f9e58aaf6
-      position: {x: -850, y: 140}
-      nodeUIDs:
-      - d4a0f09a-9dc3-4a4e-8b9d-0bc5a049c4d7|0
-      - 
-      flowUIDs: []
-      nodeValues:
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0
     - fullName: Event_Custom
       uid: 88e1f699-c450-46b2-85fd-20b65399ad98
-      position: {x: -880, y: 0}
+      position: {x: -800, y: -60}
       nodeUIDs:
       - 
       flowUIDs:
@@ -429,7 +396,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|OnUpdate
     - fullName: UnityEngineLineRenderer.__GetPositions__UnityEngineVector3Array__SystemInt32
       uid: 09dfef14-acd5-4a05-b59a-4f91484baa8c
-      position: {x: -550, y: 0}
+      position: {x: -480, y: -60}
       nodeUIDs:
       - aaf3e75f-5574-4790-8b3b-272131e9336e|0
       - 9dce16c7-8cb9-4b8a-b96a-39b7dd9b3f0b|0
@@ -690,7 +657,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid
       uid: f63ca069-77a3-43a3-9e07-11614694d7b1
-      position: {x: -270, y: 160}
+      position: {x: -400, y: 90}
       nodeUIDs:
       - 
       - 
@@ -702,11 +669,13 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|CheckColor
     - fullName: Block
       uid: b572f32d-9a0d-492d-801e-e445952e5fd2
-      position: {x: -680, y: -0}
+      position: {x: -600, y: -60}
       nodeUIDs: []
       flowUIDs:
       - 09dfef14-acd5-4a05-b59a-4f91484baa8c
       - f63ca069-77a3-43a3-9e07-11614694d7b1
+      - 41e7fb26-859b-41aa-a5fd-08bd85fc3c53
+      - b5574a61-5b81-42e8-8b86-2f1581254e2b
       nodeValues: []
     - fullName: Variable_UnityEngineColor
       uid: 081fad1c-553c-4965-ad0d-98eac079c876
@@ -753,7 +722,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|none
     - fullName: Branch
       uid: f81be6c1-15e5-4592-a078-66d43b27acb3
-      position: {x: -760, y: 1100}
+      position: {x: -880, y: 1100}
       nodeUIDs:
       - 34c37868-7dee-4ac8-bde1-977ce16a42ed
       flowUIDs:
@@ -763,7 +732,7 @@ MonoBehaviour:
         stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|False
     - fullName: Get_Variable
       uid: b8800678-7ebe-4054-9d74-3da803ed3110
-      position: {x: -1080, y: 1140}
+      position: {x: -1200, y: 1140}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -774,7 +743,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: UnityEngineColor.__op_Inequality__UnityEngineColor_UnityEngineColor__SystemBoolean
       uid: 34c37868-7dee-4ac8-bde1-977ce16a42ed
-      position: {x: -920, y: 1180}
+      position: {x: -1040, y: 1180}
       nodeUIDs:
       - b8800678-7ebe-4054-9d74-3da803ed3110
       - b1f0ad13-849c-459d-8bc4-d24234a5d9fe
@@ -788,7 +757,7 @@ MonoBehaviour:
           PublicKeyToken=null|{"r":0.0,"g":0.0,"b":0.0,"a":0.0}
     - fullName: Get_Variable
       uid: b1f0ad13-849c-459d-8bc4-d24234a5d9fe
-      position: {x: -1100, y: 1230}
+      position: {x: -1220, y: 1230}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -799,7 +768,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid
       uid: 5330fb19-b990-4465-a9d4-3c1f1d86fac0
-      position: {x: -580, y: 1100}
+      position: {x: -700, y: 1100}
       nodeUIDs:
       - 
       - 
@@ -811,7 +780,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|UpdateLineColor
     - fullName: Event_Custom
       uid: aafad91f-01b8-4b5c-9c1c-f188263e9977
-      position: {x: -1080, y: 1040}
+      position: {x: -1200, y: 1040}
       nodeUIDs:
       - 
       flowUIDs:
@@ -821,7 +790,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|CheckColor
     - fullName: VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid
       uid: f88ff416-d6c0-429f-a0e8-74efeaa2a66e
-      position: {x: -900, y: 780}
+      position: {x: -510, y: 740}
       nodeUIDs:
       - 
       - 
@@ -838,10 +807,11 @@ MonoBehaviour:
       flowUIDs:
       - cd88b179-20e7-4d23-842d-76f09578142d
       - f88ff416-d6c0-429f-a0e8-74efeaa2a66e
+      - f0b0de20-36f5-4236-9135-cdc25acd7b85
       nodeValues: []
     - fullName: UnityEngineLineRenderer.__set_startColor__UnityEngineColor__SystemVoid
       uid: cacc9f15-acbc-4954-aed4-46ae822c38a7
-      position: {x: -1150, y: 1500}
+      position: {x: -70, y: 1090}
       nodeUIDs:
       - 27b6d07f-c3ad-457a-b637-9bc8ed90db07
       - dd389a31-c212-4188-a1ba-745e93b629ca
@@ -855,7 +825,7 @@ MonoBehaviour:
           PublicKeyToken=null|{"r":0.0,"g":0.0,"b":0.0,"a":0.0}
     - fullName: UnityEngineColor.__RGBToHSV__UnityEngineColor_SystemSingleRef_SystemSingleRef_SystemSingleRef__SystemVoid
       uid: 2f853b7e-07ad-4820-b4e5-6c927f606be1
-      position: {x: -890, y: 1550}
+      position: {x: 190, y: 1140}
       nodeUIDs:
       - dd389a31-c212-4188-a1ba-745e93b629ca
       - 
@@ -875,7 +845,7 @@ MonoBehaviour:
         stringValue: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0
     - fullName: SystemSingle.__op_Subtraction__SystemSingle_SystemSingle__SystemSingle
       uid: 41c2aeb8-7e54-477b-9d7f-e76888f481fe
-      position: {x: -570, y: 1500}
+      position: {x: 530, y: 1090}
       nodeUIDs:
       - 2f853b7e-07ad-4820-b4e5-6c927f606be1
       - 
@@ -887,11 +857,11 @@ MonoBehaviour:
         stringValue: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0.1
     - fullName: UnityEngineColor.__HSVToRGB__SystemSingle_SystemSingle_SystemSingle__UnityEngineColor
       uid: a6bd1454-9108-4cb8-8c93-ed4e543cbcad
-      position: {x: -350, y: 1530}
+      position: {x: 750, y: 1140}
       nodeUIDs:
       - 41c2aeb8-7e54-477b-9d7f-e76888f481fe
       - 2f853b7e-07ad-4820-b4e5-6c927f606be1|1
-      - 
+      - 2f853b7e-07ad-4820-b4e5-6c927f606be1|2
       flowUIDs: []
       nodeValues:
       - unityObjectValue: {fileID: 0}
@@ -902,7 +872,7 @@ MonoBehaviour:
         stringValue: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0
     - fullName: UnityEngineLineRenderer.__set_endColor__UnityEngineColor__SystemVoid
       uid: 68529915-8975-43b9-b4d2-7b5b2ec48b97
-      position: {x: -130, y: 1550}
+      position: {x: 970, y: 1140}
       nodeUIDs:
       - 27b6d07f-c3ad-457a-b637-9bc8ed90db07
       - a6bd1454-9108-4cb8-8c93-ed4e543cbcad
@@ -915,7 +885,7 @@ MonoBehaviour:
           PublicKeyToken=null|{"r":0.0,"g":0.0,"b":0.0,"a":0.0}
     - fullName: Get_Variable
       uid: dd389a31-c212-4188-a1ba-745e93b629ca
-      position: {x: -1330, y: 1650}
+      position: {x: -250, y: 1240}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -926,7 +896,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: Event_Custom
       uid: 0a9978b4-e9d2-459e-813c-7bd6cf316274
-      position: {x: -1370, y: 1440}
+      position: {x: -310, y: 1030}
       nodeUIDs:
       - 
       flowUIDs:
@@ -936,7 +906,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|UpdateLineColor
     - fullName: Get_Variable
       uid: 27b6d07f-c3ad-457a-b637-9bc8ed90db07
-      position: {x: -1370, y: 1540}
+      position: {x: -310, y: 1130}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -945,31 +915,9 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|d4139c3b-f0b7-4103-b844-bc897daa6ec5
       - unityObjectValue: {fileID: 0}
         stringValue: 
-    - fullName: Event_Custom
-      uid: 6ee49b92-f9f3-427a-bf57-59fed8d9061d
-      position: {x: -850, y: 1930}
-      nodeUIDs:
-      - 
-      flowUIDs:
-      - 28a84de1-3068-4ac9-a7b9-22addfe918ee
-      nodeValues:
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|Erase
-    - fullName: UnityEngineGameObject.__SetActive__SystemBoolean__SystemVoid
-      uid: 28a84de1-3068-4ac9-a7b9-22addfe918ee
-      position: {x: -630, y: 1930}
-      nodeUIDs:
-      - 
-      - 
-      flowUIDs: []
-      nodeValues:
-      - unityObjectValue: {fileID: 0}
-        stringValue: 
-      - unityObjectValue: {fileID: 0}
-        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|False
     - fullName: UnityEngineLineRenderer.__BakeMesh__UnityEngineMesh_SystemBoolean__SystemVoid
       uid: c63c8c91-c08a-41e1-a772-52e480e95526
-      position: {x: 1140, y: 650}
+      position: {x: 420, y: 510}
       nodeUIDs:
       - 3a567ac6-37e7-45e4-9267-be52bb192ccd
       - 4be10c6d-cf52-426f-8180-378dcccaaeb7
@@ -988,7 +936,7 @@ MonoBehaviour:
         stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|True
     - fullName: Event_Custom
       uid: a99bb75b-1c15-49a5-b57b-41c0ff272dfc
-      position: {x: 840, y: 630}
+      position: {x: 120, y: 490}
       nodeUIDs:
       - 
       flowUIDs:
@@ -998,7 +946,7 @@ MonoBehaviour:
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|BakeMesh
     - fullName: Get_Variable
       uid: 3a567ac6-37e7-45e4-9267-be52bb192ccd
-      position: {x: 820, y: 720}
+      position: {x: 100, y: 580}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -1009,7 +957,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: Get_Variable
       uid: 351772dd-494d-49cf-8a1d-a453b9c89cca
-      position: {x: 1100, y: 840}
+      position: {x: 380, y: 700}
       nodeUIDs:
       - 351772dd-494d-49cf-8a1d-a453b9c89cca
       flowUIDs: []
@@ -1020,7 +968,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: UnityEngineMeshCollider.__set_sharedMesh__UnityEngineMesh__SystemVoid
       uid: 0d8beb35-b587-457b-8862-fe4c02e11f25
-      position: {x: 1340, y: 830}
+      position: {x: 620, y: 690}
       nodeUIDs:
       - 351772dd-494d-49cf-8a1d-a453b9c89cca
       - 4be10c6d-cf52-426f-8180-378dcccaaeb7
@@ -1033,7 +981,7 @@ MonoBehaviour:
         stringValue: 
     - fullName: Get_Variable
       uid: 4be10c6d-cf52-426f-8180-378dcccaaeb7
-      position: {x: 900, y: 880}
+      position: {x: 180, y: 740}
       nodeUIDs:
       - 
       flowUIDs: []
@@ -1058,11 +1006,110 @@ MonoBehaviour:
           Version=1.0.0.0, Culture=neutral, PublicKeyToken=null|All
       - unityObjectValue: {fileID: 0}
         stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|BakeMesh
+    - fullName: Event_Custom
+      uid: 7ec391db-8a39-4008-be46-242a54340fd6
+      position: {x: -1240, y: 1460}
+      nodeUIDs:
+      - 
+      flowUIDs:
+      - 6e631eef-f8a3-4717-87e4-608cf3b0b2aa
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|Erase
+    - fullName: Branch
+      uid: 6e631eef-f8a3-4717-87e4-608cf3b0b2aa
+      position: {x: -1020, y: 1460}
+      nodeUIDs:
+      - 78f1a21e-071c-4139-b5ac-4616a0470af9
+      flowUIDs:
+      - f35dd98b-a136-46ed-9295-7934caaf1e5d
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|False
+    - fullName: VRCSDKBaseNetworking.__IsOwner__UnityEngineGameObject__SystemBoolean
+      uid: 78f1a21e-071c-4139-b5ac-4616a0470af9
+      position: {x: -1220, y: 1560}
+      nodeUIDs:
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+    - fullName: Get_Variable
+      uid: f475453b-9165-4e1c-bd8e-44c86e548764
+      position: {x: -1000, y: 1580}
+      nodeUIDs:
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|d4139c3b-f0b7-4103-b844-bc897daa6ec5
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+    - fullName: UnityEngineLineRenderer.__set_positionCount__SystemInt32__SystemVoid
+      uid: f35dd98b-a136-46ed-9295-7934caaf1e5d
+      position: {x: -760, y: 1460}
+      nodeUIDs:
+      - f475453b-9165-4e1c-bd8e-44c86e548764|0
+      - 
+      flowUIDs:
+      - e46d30cc-4f59-4d51-aad9-2dce73cb9c10
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|0
+    - fullName: VRCUdonCommonInterfacesIUdonEventReceiver.__SendCustomEvent__SystemString__SystemVoid
+      uid: e46d30cc-4f59-4d51-aad9-2dce73cb9c10
+      position: {x: -560, y: 1460}
+      nodeUIDs:
+      - 
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|OnUpdate
+    - fullName: VRCUdonCommonInterfacesIUdonEventReceiver.__RequestSerialization__SystemVoid
+      uid: 41e7fb26-859b-41aa-a5fd-08bd85fc3c53
+      position: {x: -380, y: 230}
+      nodeUIDs:
+      - 
+      flowUIDs:
+      - 
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+    - fullName: UnityEngineLineRenderer.__set_enabled__SystemBoolean__SystemVoid
+      uid: f0b0de20-36f5-4236-9135-cdc25acd7b85
+      position: {x: -860, y: 770}
+      nodeUIDs:
+      - 26b001e6-406f-4d3e-bd2c-0a5bb2e511d6|0
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|True
+    - fullName: UnityEngineLineRenderer.__set_enabled__SystemBoolean__SystemVoid
+      uid: b5574a61-5b81-42e8-8b86-2f1581254e2b
+      position: {x: -150, y: 230}
+      nodeUIDs:
+      - aaf3e75f-5574-4790-8b3b-272131e9336e|0
+      - 
+      flowUIDs: []
+      nodeValues:
+      - unityObjectValue: {fileID: 0}
+        stringValue: 
+      - unityObjectValue: {fileID: 0}
+        stringValue: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|True
     updateOrder: 0
   graphElementData:
   - type: 2
     uid: 582b9bc5-eaab-4254-9672-6dd07de9ef1c
-    jsonData: '{"uid":"582b9bc5-eaab-4254-9672-6dd07de9ef1c","layout":{"serializedVersion":"2","x":-1220.0,"y":380.0,"width":1118.0,"height":552.0},"containedElements":["b08ad0aa-7980-402b-b9c3-9b9ab385febc","cd88b179-20e7-4d23-842d-76f09578142d","26b001e6-406f-4d3e-bd2c-0a5bb2e511d6","927d1cb8-d331-49d9-9531-c7bfe4b9c796","e11f63e2-0222-48dc-b22c-d1b58d2ddba0","f61dd935-f54c-41bf-b4c1-7f819e8ede51","f88ff416-d6c0-429f-a0e8-74efeaa2a66e","c248ca63-398c-446b-afea-3afe66339ddd"],"title":"Set
+    jsonData: '{"uid":"582b9bc5-eaab-4254-9672-6dd07de9ef1c","layout":{"serializedVersion":"2","x":-1220.0,"y":380.0,"width":1118.0,"height":542.0},"containedElements":["b08ad0aa-7980-402b-b9c3-9b9ab385febc","cd88b179-20e7-4d23-842d-76f09578142d","26b001e6-406f-4d3e-bd2c-0a5bb2e511d6","927d1cb8-d331-49d9-9531-c7bfe4b9c796","e11f63e2-0222-48dc-b22c-d1b58d2ddba0","f61dd935-f54c-41bf-b4c1-7f819e8ede51","f88ff416-d6c0-429f-a0e8-74efeaa2a66e","c248ca63-398c-446b-afea-3afe66339ddd","87b57e42-b3f3-4312-8b57-8006a72e9272","85426dcd-07d0-4e0c-9a34-fdccc2193ca2","04a2d94a-4c84-41d4-ad1a-2f76a28c8631","58b86a30-1042-4361-abe8-618e3eaa9109","d54bc31e-72a6-46c8-9a43-8c5d068793f8","b497fd1d-bb4f-4b7d-a825-a36942133115","d1c0e739-adb3-481a-b4f8-8b1e9d0397ce","f0b0de20-36f5-4236-9135-cdc25acd7b85"],"title":"Set
       LinePositions from Synced Data, Check for Color Updates","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: ee8529df-6d2b-47b0-aaeb-a2c9f73e2895
@@ -1070,7 +1117,7 @@ MonoBehaviour:
       Update Points Array from LineRenderer and Bake the Mesh Collider","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: cd33cf70-0bc3-43db-ac00-0b5eaea3e7c1
-    jsonData: '{"uid":"cd33cf70-0bc3-43db-ac00-0b5eaea3e7c1","layout":{"serializedVersion":"2","x":90.0,"y":550.0,"width":639.0,"height":265.0},"containedElements":["3cd76e77-e278-4901-82f1-7e5471ca4020","3973ee95-2edf-462a-bf82-13d1ae9ddb06","282e165c-f7e1-4f48-ac66-0caf0eb2ae0a"],"title":"Allow
+    jsonData: '{"uid":"cd33cf70-0bc3-43db-ac00-0b5eaea3e7c1","layout":{"serializedVersion":"2","x":-230.0,"y":1390.0,"width":631.0,"height":264.0},"containedElements":["3cd76e77-e278-4901-82f1-7e5471ca4020","3973ee95-2edf-462a-bf82-13d1ae9ddb06","282e165c-f7e1-4f48-ac66-0caf0eb2ae0a"],"title":"Allow
       Ownership Changes","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: 019e6437-e965-421e-b090-6c82a78cb746
@@ -1092,29 +1139,29 @@ MonoBehaviour:
       LineMesh","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: e1f1b054-6654-41d6-8b91-4ef815c32248
-    jsonData: '{"uid":"e1f1b054-6654-41d6-8b91-4ef815c32248","layout":{"serializedVersion":"2","x":-1320.0,"y":-70.0,"width":1352.0,"height":382.0},"containedElements":["aaf3e75f-5574-4790-8b3b-272131e9336e","d4a0f09a-9dc3-4a4e-8b9d-0bc5a049c4d7","17221806-01ea-49ac-abf8-f67f9e58aaf6","9dce16c7-8cb9-4b8a-b96a-39b7dd9b3f0b","88e1f699-c450-46b2-85fd-20b65399ad98","09dfef14-acd5-4a05-b59a-4f91484baa8c","20e09264-191b-4018-b392-04b751a99277","c6cd907a-9fa4-483b-8d26-a12cc00369d1","f63ca069-77a3-43a3-9e07-11614694d7b1","b572f32d-9a0d-492d-801e-e445952e5fd2"],"title":"OnUpdate
-      event, set points from current line positions and check for color changes","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
+    jsonData: '{"uid":"e1f1b054-6654-41d6-8b91-4ef815c32248","layout":{"serializedVersion":"2","x":-1250.0,"y":-130.0,"width":1264.0,"height":512.0},"containedElements":["aaf3e75f-5574-4790-8b3b-272131e9336e","d4a0f09a-9dc3-4a4e-8b9d-0bc5a049c4d7","17221806-01ea-49ac-abf8-f67f9e58aaf6","9dce16c7-8cb9-4b8a-b96a-39b7dd9b3f0b","88e1f699-c450-46b2-85fd-20b65399ad98","09dfef14-acd5-4a05-b59a-4f91484baa8c","20e09264-191b-4018-b392-04b751a99277","c6cd907a-9fa4-483b-8d26-a12cc00369d1","f63ca069-77a3-43a3-9e07-11614694d7b1","b572f32d-9a0d-492d-801e-e445952e5fd2","2fe99bc9-3ad3-42fa-8001-3a5b2823b39f","27045f72-30f0-4d10-a83b-0c62107e7d4b","799374b7-b962-494f-98ab-4fe2e4dab929","f7da410b-84ed-42bf-b4e3-824377c37e91","41e7fb26-859b-41aa-a5fd-08bd85fc3c53","b5574a61-5b81-42e8-8b86-2f1581254e2b"],"title":"OnUpdate
+      event, set points from current line positions, check for color changes","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: 34a3be36-d111-4f8e-b955-19f05265e0cb
-    jsonData: '{"uid":"34a3be36-d111-4f8e-b955-19f05265e0cb","layout":{"serializedVersion":"2","x":-1120.0,"y":970.0,"width":848.0,"height":365.0},"containedElements":["f81be6c1-15e5-4592-a078-66d43b27acb3","b8800678-7ebe-4054-9d74-3da803ed3110","34c37868-7dee-4ac8-bde1-977ce16a42ed","b1f0ad13-849c-459d-8bc4-d24234a5d9fe","5330fb19-b990-4465-a9d4-3c1f1d86fac0","aafad91f-01b8-4b5c-9c1c-f188263e9977"],"title":"Check
+    jsonData: '{"uid":"34a3be36-d111-4f8e-b955-19f05265e0cb","layout":{"serializedVersion":"2","x":-1240.0,"y":970.0,"width":845.0,"height":364.0},"containedElements":["f81be6c1-15e5-4592-a078-66d43b27acb3","b8800678-7ebe-4054-9d74-3da803ed3110","34c37868-7dee-4ac8-bde1-977ce16a42ed","b1f0ad13-849c-459d-8bc4-d24234a5d9fe","5330fb19-b990-4465-a9d4-3c1f1d86fac0","aafad91f-01b8-4b5c-9c1c-f188263e9977"],"title":"Check
       for Color Changes","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 5
     uid: 6327578b-c63e-463b-a310-ab3753c2c122
     jsonData: '{"visible":true,"layout":{"serializedVersion":"2","x":8.0,"y":145.0,"width":205.0,"height":257.0}}'
   - type: 2
     uid: 60268cbd-b7ac-4ae3-b433-403e0a075b01
-    jsonData: '{"uid":"60268cbd-b7ac-4ae3-b433-403e0a075b01","layout":{"serializedVersion":"2","x":-1400.0,"y":1380.0,"width":1444.0,"height":406.0},"containedElements":["cacc9f15-acbc-4954-aed4-46ae822c38a7","2f853b7e-07ad-4820-b4e5-6c927f606be1","41c2aeb8-7e54-477b-9d7f-e76888f481fe","a6bd1454-9108-4cb8-8c93-ed4e543cbcad","39902f5e-4ecf-4f42-b53d-fd1580099780","68529915-8975-43b9-b4d2-7b5b2ec48b97","dd389a31-c212-4188-a1ba-745e93b629ca","0a9978b4-e9d2-459e-813c-7bd6cf316274","27b6d07f-c3ad-457a-b637-9bc8ed90db07"],"title":"Set
+    jsonData: '{"uid":"60268cbd-b7ac-4ae3-b433-403e0a075b01","layout":{"serializedVersion":"2","x":-340.0,"y":960.0,"width":1482.0,"height":384.0},"containedElements":["cacc9f15-acbc-4954-aed4-46ae822c38a7","2f853b7e-07ad-4820-b4e5-6c927f606be1","41c2aeb8-7e54-477b-9d7f-e76888f481fe","a6bd1454-9108-4cb8-8c93-ed4e543cbcad","39902f5e-4ecf-4f42-b53d-fd1580099780","68529915-8975-43b9-b4d2-7b5b2ec48b97","dd389a31-c212-4188-a1ba-745e93b629ca","0a9978b4-e9d2-459e-813c-7bd6cf316274","27b6d07f-c3ad-457a-b637-9bc8ed90db07"],"title":"Set
       Line Color","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: 705d96e8-7f70-47f9-8a79-a2c11f0c9f74
-    jsonData: '{"uid":"705d96e8-7f70-47f9-8a79-a2c11f0c9f74","layout":{"serializedVersion":"2","x":-870.0,"y":1860.0,"width":410.0,"height":223.0},"containedElements":["6ee49b92-f9f3-427a-bf57-59fed8d9061d","28a84de1-3068-4ac9-a7b9-22addfe918ee"],"title":"Network
+    jsonData: '{"uid":"705d96e8-7f70-47f9-8a79-a2c11f0c9f74","layout":{"serializedVersion":"2","x":-1260.0,"y":1390.0,"width":1005.0,"height":296.0},"containedElements":["6ee49b92-f9f3-427a-bf57-59fed8d9061d","28a84de1-3068-4ac9-a7b9-22addfe918ee","7ec391db-8a39-4008-be46-242a54340fd6","58a4c995-15c9-4556-a084-2014fab17477","6e631eef-f8a3-4717-87e4-608cf3b0b2aa","78f1a21e-071c-4139-b5ac-4616a0470af9","74337fe1-6c71-4cde-a04b-35c46c32616e","ed12ec63-6a1d-4072-96a2-1df9bc615eb9","b3f5101d-eebb-4802-a942-2b5ced1fdfec","b1e0bfe8-c97a-4aef-a590-7a3b80fddd07","ff9bfde3-a4be-4997-88ca-a505c607fc17","f475453b-9165-4e1c-bd8e-44c86e548764","f35dd98b-a136-46ed-9295-7934caaf1e5d","13b66b3a-cf35-40c4-bece-ca530e0c0029","30aa6d77-0686-4658-8e3b-a5eeeef05027","e46d30cc-4f59-4d51-aad9-2dce73cb9c10"],"title":"Network
       Erase Event","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   - type: 2
     uid: 46f2b95d-f5f5-484c-85b1-67af7aab147b
-    jsonData: '{"uid":"46f2b95d-f5f5-484c-85b1-67af7aab147b","layout":{"serializedVersion":"2","x":800.0,"y":570.0,"width":748.0,"height":422.0},"containedElements":["c63c8c91-c08a-41e1-a772-52e480e95526","a99bb75b-1c15-49a5-b57b-41c0ff272dfc","3a567ac6-37e7-45e4-9267-be52bb192ccd","351772dd-494d-49cf-8a1d-a453b9c89cca","0d8beb35-b587-457b-8862-fe4c02e11f25","4be10c6d-cf52-426f-8180-378dcccaaeb7"],"title":"Bake
+    jsonData: '{"uid":"46f2b95d-f5f5-484c-85b1-67af7aab147b","layout":{"serializedVersion":"2","x":80.0,"y":420.0,"width":745.0,"height":424.0},"containedElements":["c63c8c91-c08a-41e1-a772-52e480e95526","a99bb75b-1c15-49a5-b57b-41c0ff272dfc","3a567ac6-37e7-45e4-9267-be52bb192ccd","351772dd-494d-49cf-8a1d-a453b9c89cca","0d8beb35-b587-457b-8862-fe4c02e11f25","4be10c6d-cf52-426f-8180-378dcccaaeb7"],"title":"Bake
       Mesh Collider","layer":0,"elementTypeColor":{"r":0.0,"g":0.0,"b":0.0,"a":0.0}}'
   viewTransform:
-    position: {x: 800.8791, y: -815.3519}
+    position: {x: 1082.6697, y: 326.57947}
     scale: 0.7561437
   version: 1.0.0
   showAssembly: 0

--- a/Assets/_WorldJam1/Drawing/UdonPrograms/Stylus.asset
+++ b/Assets/_WorldJam1/Drawing/UdonPrograms/Stylus.asset
@@ -1708,7 +1708,7 @@ MonoBehaviour:
     uid: dc0a01cb-b0a2-4dad-8220-1d5d34238fc4
     jsonData: '{"visible":true,"layout":{"serializedVersion":"2","x":10.0,"y":130.0,"width":245.0,"height":508.0}}'
   viewTransform:
-    position: {x: 1384.4956, y: 248.39136}
-    scale: 0.49717674
+    position: {x: 1092.2866, y: -288.01337}
+    scale: 0.7561437
   version: 1.0.0
   showAssembly: 0


### PR DESCRIPTION
Fixes erasers for late joiners by making the Erase event only send to Owners, who then set the number of line positions to 0 and call the "OnUpdate" event, which serializes the points data to everyone else.

Also changes Lines to use "Mobile/Diffuse" shader instead of "Mobile/Particles/AlphaBlended" to fix some sorting issues when drawing spirals, etc.